### PR TITLE
chore: bump webidl-dts-gen from 1.0.2 to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "jolt-physics",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jolt-physics",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",
-        "webidl-dts-gen": "^1.0.2"
+        "webidl-dts-gen": "^1.1.1"
       }
     },
     "../webidl2ts": {
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/webidl-dts-gen": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-dts-gen/-/webidl-dts-gen-1.0.2.tgz",
-      "integrity": "sha512-4mkrLU2L6W1/a5Jcf1bDvl0IjWFNXXrs6oFBISuOQ3BLb1nYgTj4oagfm/omGw9O6nCYQorkByBI41/Yb1KVHA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webidl-dts-gen/-/webidl-dts-gen-1.1.1.tgz",
+      "integrity": "sha512-sD6jcs8Y8CVoCa4xzYeJBv57/WnkIsKqE+yjUCEcFC02zEEUwgotZg4qdQYYS1aX+4UFoSKtHwe+sbJdjpFU0g==",
       "dev": true,
       "dependencies": {
         "jsdom": "^21.1.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   ],
   "devDependencies": {
     "http-server": "^14.1.1",
-    "webidl-dts-gen": "^1.0.2"
+    "webidl-dts-gen": "^1.1.1"
   }
 }


### PR DESCRIPTION
- bump webidl-dts-gen from 1.0.2 to 1.1.1
  - includes improvements to  generated types for enums with the emscripten mode enabled
  - see changelog: https://github.com/pmndrs/webidl-dts-gen/blob/main/packages/webidl-dts-gen/CHANGELOG.md

---

Previously, the generated typescript type for an enum was a union of the member name strings. This is the desired behaviour for the webidl spec, but does not match the bindings that emscripten generates.

For example, looking at the `Layers` enum:

```cpp
enum class Layers
{
    NON_MOVING = 0,
    MOVING = 1,
    NUM_LAYERS = 2
};
```

With the following webidl:

```
enum Layers {
    "Layers::MOVING",
    "Layers::NON_MOVING"
};
```

This typescript type was generated:

```ts
type Layers = "Layers::MOVING" | "Layers::NON_MOVING";
```

There's a few issues with this with regards to emscripten-generated bindings:
- The enum values aren't strings, but numbers. Also, with the information in the webidl alone, the value type isn't actually known
- Types for `Jolt.MOVING` and `Jolt.NON_MOVING` aren't present
- Types for the emscripten functions `_emscripten_enum_Layers_MOVING`  and `_emscripten_enum_Layers_NON_MOVING` aren't present

With `webidl-dts-gen` v1.1.1, the output for enums in emscripten mode is now:

```ts
const MOVING: any;
const NON_MOVING: any;
type Layers = typeof MOVING | typeof NON_MOVING;
function _emscripten_enum_Layers_MOVING(): Layers;
function _emscripten_enum_Layers_NON_MOVING(): Layers;
```