### PR TITLE
chore: bump webidl-dts-gen from 1.1.1 to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",
-        "webidl-dts-gen": "^1.1.1"
+        "webidl-dts-gen": "^1.7.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/webidl-dts-gen": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/webidl-dts-gen/-/webidl-dts-gen-1.6.0.tgz",
-      "integrity": "sha512-JAIIrQEquQ5VcIIrzwHmy5HhbgBK7/foTYdtzCw9CmKlCSwJ9wqipoyLGFa4cV1ABp7uuC1uKnPR08WsUkiE9A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/webidl-dts-gen/-/webidl-dts-gen-1.7.0.tgz",
+      "integrity": "sha512-njTx5pWAAf4kF6ZdAn3xidMBEZ6SIotDQQGQNvNYkzsjASNAMkPD36nai/u+YSafKTaMQvjY49DCrX835U+Jew==",
       "dev": true,
       "dependencies": {
         "jsdom": "^22.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   ],
   "devDependencies": {
     "http-server": "^14.1.1",
-    "webidl-dts-gen": "^1.1.1"
+    "webidl-dts-gen": "^1.7.0"
   }
 }


### PR DESCRIPTION
Bumps `webidl-dts-gen` from 1.1.1 to 1.7.0

Changelog: https://github.com/pmndrs/webidl-dts-gen/blob/main/packages/webidl-dts-gen/CHANGELOG.md

The new versions have various fixes to generated types to more closely match emscripten generated javascript