### PR TITLE
chore: build and deploy examples

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -12,9 +12,15 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-        
-    - name: Replace URL
-      run: sed -i 's+./js/jolt-physics.wasm-compat.js+https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js+g' ${{github.workspace}}/Examples/*.html
+
+    - name: Setup Node.js 18.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18.x
+
+    - name: Build
+      run: ./ci/build-examples.sh
+      shell: bash
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/ci/build-examples.sh
+++ b/ci/build-examples.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+npm install
+
+bash ./ci/install-emsdk.sh
+source ./emsdk/emsdk_env.sh
+
+npm run build

--- a/ci/install-emsdk.sh
+++ b/ci/install-emsdk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+EMSDK_VERSION=3.1.46
+
+git clone https://github.com/emscripten-core/emsdk.git
+
+cd emsdk
+
+./emsdk install $EMSDK_VERSION
+./emsdk activate $EMSDK_VERSION


### PR DESCRIPTION
Partially addresses #8 - the lib is built when deploying examples

Tested the action on my fork - https://isaac-mason.github.io/JoltPhysics.js/

The action takes ~3 minutes to run, there are likely ways to make this faster