### PR TITLE
fix: incorrect 'main' and 'types' fields in entrypoint package.json files 

### DIFF
--- a/wasm-compat/package.json
+++ b/wasm-compat/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
-  "main": "../dist/jolt-physics.wasm.js",
-  "types": "../dist/jolt-physics.d.ts"
+  "main": "../dist/jolt-physics.wasm-compat.js",
+  "types": "../dist/jolt-physics.wasm-compat.d.ts"
 }

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
-  "main": "../dist/jolt-physics.js",
-  "types": "../dist/jolt-physics.d.ts"
+  "main": "../dist/jolt-physics.wasm.js",
+  "types": "../dist/jolt-physics.wasm.d.ts"
 }


### PR DESCRIPTION
- The package.json `main` fields were incorrect for the `wasm-compat` and `wasm` entrypoints 
  - This may have had no impact on users, it may only be CommonJS node environments that use this `main` field instead of via the `exports` defined in the main `package.json`. We don't have a CommonJS build right now, we have an ESM build
  - Updating for now, and I can separately investigate whether we need these
- The `types` fields were also updated, but this is just for posterity, all the types files have the same contents