### PR TITLE
fix(package.json): order of 'types' and 'default' in 'exports'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "types": "dist/jolt-physics.wasm-compat.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/jolt-physics.wasm-compat.js",
-      "types": "./dist/jolt-physics.wasm-compat.d.ts"
+      "types": "./dist/jolt-physics.wasm-compat.d.ts",
+      "default": "./dist/jolt-physics.wasm-compat.js"
     },
     "./wasm": {
-      "default": "./dist/jolt-physics.wasm.js",
-      "types": "./dist/jolt-physics.wasm.d.ts"
+      "types": "./dist/jolt-physics.wasm.d.ts",
+      "default": "./dist/jolt-physics.wasm.js"
     },
     "./wasm-compat": {
-      "default": "./dist/jolt-physics.wasm-compat.js",
-      "types": "./dist/jolt-physics.wasm-compat.d.ts"
+      "types": "./dist/jolt-physics.wasm-compat.d.ts",
+      "default": "./dist/jolt-physics.wasm-compat.js"
     },
     "./asm": {
-      "default": "./dist/jolt-physics.js",
-      "types": "./dist/jolt-physics.d.ts"
+      "types": "./dist/jolt-physics.d.ts",
+      "default": "./dist/jolt-physics.js"
     },
     "./jolt-physics.wasm.wasm": "./dist/jolt-physics.wasm.wasm",
     "./package.json": "./package.json"


### PR DESCRIPTION
### Change
fix(package.json): order of 'types' and 'default' in 'exports'

### Motivation
Partially addresses #52 

> The "types" condition should always come first in "exports".

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing