### PR TITLE
Switch BP layers attributes to constants

### DIFF
--- a/Examples/js/example.js
+++ b/Examples/js/example.js
@@ -76,8 +76,8 @@ function initPhysics() {
 	objectFilter.EnableCollision(LAYER_MOVING, LAYER_MOVING);
 
 	// We use a 1-to-1 mapping between object layers and broadphase layers
-	const BP_LAYER_NON_MOVING = new Jolt.BroadPhaseLayer(0);
-	const BP_LAYER_MOVING = new Jolt.BroadPhaseLayer(1);
+	const BP_LAYER_NON_MOVING = new Jolt.BroadPhaseLayer(LAYER_NON_MOVING);
+	const BP_LAYER_MOVING = new Jolt.BroadPhaseLayer(LAYER_MOVING);
 	let bpInterface = new Jolt.BroadPhaseLayerInterfaceTable(2, 2);
 	bpInterface.MapObjectToBroadPhaseLayer(LAYER_NON_MOVING, BP_LAYER_NON_MOVING);
 	bpInterface.MapObjectToBroadPhaseLayer(LAYER_MOVING, BP_LAYER_MOVING);


### PR DESCRIPTION
PR switches the attributes of BP layer methods from scalars to constants for clarity:

```js
// from
new Jolt.BroadPhaseLayer(0);
// to
new Jolt.BroadPhaseLayer(LAYER_NON_MOVING);
```