### PR TITLE
Feature: HeightField Shape + Example

### DIFF
--- a/Examples/buoyancy.html
+++ b/Examples/buoyancy.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="style.css">
+	</head>
+
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js bouyancy demo<br />
+		</div>
+
+		<script src="js/three/three.min.js"></script>
+		<script src="js/three/OrbitControls.js"></script>
+		<script src="js/three/WebGL.js"></script>
+		<script src="js/three/stats.min.js"></script>
+		<script src="js/example.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from './js/jolt-physics.wasm-compat.js';
+
+
+      function createSensorBox(position, rotation, halfExtent, motionType, layer, color = 0xffffff) {
+        let shape = new Jolt.BoxShape(halfExtent, 0.05, null);
+        let creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, motionType, layer);
+        creationSettings.mIsSensor = true;
+        let body = bodyInterface.CreateBody(creationSettings);
+        Jolt.destroy(creationSettings);
+        addToScene(body, color);
+        return body;
+      }
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+				
+        const position = new Jolt.Vec3(12, 8, -15);
+        const rotation = Jolt.Quat.prototype.sRotation(new Jolt.Vec3(0, 0, 1), -0.2 * Math.PI);
+        const ident = new Jolt.Quat(0,0,0,1);
+        const size = new Jolt.Vec3(.2, 6, 1)
+        createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+        size.SetY(4);
+        position.Set(8.5,-1,-15);
+        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+        position.Set(0,-6,-15);
+        size.SetY(5);
+        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+        size.SetY(3.25);
+        position.Set(-15,-8,-15);
+        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+
+        size.Set(30,3,1);
+        position.Set(-8,-14,-15);
+        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+
+        size.SetX(11);
+        position.Set(11,-8,-15);
+        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+
+
+        position.Set(10, 12, -15);
+				const ball = createSphere(position, 1, Jolt.EMotionType_Dynamic, LAYER_MOVING, 0xFF0000);
+        const ballID = ball.GetID().GetIndexAndSequenceNumber();
+
+				const contactListener = new Jolt.ContactListenerJS();
+
+        size.Set(5.5,4.5,1.5);
+        position.Set(5.5, -2, -15);
+        const movingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1111FF);
+        const movingWaterID = movingWater.GetID().GetIndexAndSequenceNumber();
+        const waterThreeModel = dynamicObjects[dynamicObjects.length - 1];
+        waterThreeModel.material.wireframe = true;
+        
+        size.Set(7.5,2,1.5);
+        position.Set(-7.5, -8.5, -15);
+        const standingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1133FF);
+        const standingWaterID = standingWater.GetID().GetIndexAndSequenceNumber();
+        const standingThreeModel = dynamicObjects[dynamicObjects.length - 1];
+        standingThreeModel.material.wireframe = true;
+
+
+        const inBuoyancy = 1.1;
+        const inLinearDrag = 0.3;
+        const inAngularDrag = 0.05;
+        const inSurfaceNormal = new Jolt.Vec3(0, 1, 0);
+        const inGravity = new Jolt.Vec3(0, -9.8, 0);
+
+        const inMovingFluidVelocity = new Jolt.Vec3(-0.5, 0, 0);
+        const inMovingWaterSurfacePosition = new Jolt.Vec3(0, 2.5, 0);
+
+        const inStandingWaterSurfacePosition = new Jolt.Vec3(0, -6.5, 0);
+        const inNoFluidVelocity = new Jolt.Vec3(0, 0, 0);
+
+        let inDeltaTime = 1/60;
+
+        function OnContact(body1, body2, manifold, settings) {
+					body1 = Jolt.wrapPointer(body1, Jolt.Body);
+					body2 = Jolt.wrapPointer(body2, Jolt.Body);
+          const body1ID = body1.GetID().GetIndexAndSequenceNumber();
+          const body2ID = body2.GetID().GetIndexAndSequenceNumber();
+          if (body1ID == ballID || body2ID == ballID) {
+            if (body1ID == movingWaterID || body2ID == movingWaterID) {
+              ball.ApplyBuoyancyImpulse(inMovingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inMovingFluidVelocity, inGravity, inDeltaTime);
+            }
+            if (body1ID == standingWaterID || body2ID == standingWaterID) {
+            ball.ApplyBuoyancyImpulse(inStandingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inNoFluidVelocity, inGravity, inDeltaTime);
+            }
+          }
+          
+        }
+
+				contactListener.OnContactAdded = OnContact;
+				contactListener.OnContactPersisted = OnContact;
+
+        contactListener.OnContactValidate = (body1, body2, baseOffset, collideShapeResult) => {
+					return Jolt.ValidateResult_AcceptAllContactsForThisBodyPair;
+				};
+				contactListener.OnContactRemoved = (subShapePair) => {};
+				physicsSystem.SetContactListener(contactListener);
+
+        onExampleUpdate = function (time, deltaTime) {
+          inDeltaTime = deltaTime; 
+        }
+
+			});
+
+		</script>
+	</body>
+</html>

--- a/Examples/buoyancy.html
+++ b/Examples/buoyancy.html
@@ -23,110 +23,105 @@
 			import initJolt from './js/jolt-physics.wasm-compat.js';
 
 
-      function createSensorBox(position, rotation, halfExtent, motionType, layer, color = 0xffffff) {
-        let shape = new Jolt.BoxShape(halfExtent, 0.05, null);
-        let creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, motionType, layer);
-        creationSettings.mIsSensor = true;
-        let body = bodyInterface.CreateBody(creationSettings);
-        Jolt.destroy(creationSettings);
-        addToScene(body, color);
-        return body;
-      }
+			function createSensorBox(position, rotation, halfExtent, motionType, layer, color = 0xffffff) {
+				let shape = new Jolt.BoxShape(halfExtent, 0.05, null);
+				let creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, motionType, layer);
+				creationSettings.mIsSensor = true;
+				let body = bodyInterface.CreateBody(creationSettings);
+				Jolt.destroy(creationSettings);
+				addToScene(body, color);
+				return body;
+			}
 
 			initJolt().then(async function (Jolt) {
 				// Initialize this example
 				initExample(Jolt, null);
-				
-        const position = new Jolt.Vec3(12, 8, -15);
-        const rotation = Jolt.Quat.prototype.sRotation(new Jolt.Vec3(0, 0, 1), -0.2 * Math.PI);
-        const ident = new Jolt.Quat(0,0,0,1);
-        const size = new Jolt.Vec3(.2, 6, 1)
-        createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-        size.SetY(4);
-        position.Set(8.5,-1,-15);
-        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-        position.Set(0,-6,-15);
-        size.SetY(5);
-        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-        size.SetY(3.25);
-        position.Set(-15,-8,-15);
-        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
 
-        size.Set(30,3,1);
-        position.Set(-8,-14,-15);
-        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const position = new Jolt.Vec3(12, 8, -15);
+				const rotation = Jolt.Quat.prototype.sRotation(new Jolt.Vec3(0, 0, 1), -0.2 * Math.PI);
+				const ident = new Jolt.Quat(0, 0, 0, 1);
+				const size = new Jolt.Vec3(.2, 6, 1)
+				createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				size.SetY(4);
+				position.Set(8.5, -1, -15);
+				createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				position.Set(0, -6, -15);
+				size.SetY(5);
+				createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				size.SetY(3.25);
+				position.Set(-15, -8, -15);
+				createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
 
-        size.SetX(11);
-        position.Set(11,-8,-15);
-        createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				size.Set(30, 3, 1);
+				position.Set(-8, -14, -15);
+				createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
 
+				size.SetX(11);
+				position.Set(11, -8, -15);
+				createBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
 
-        position.Set(10, 12, -15);
+				position.Set(10, 12, -15);
 				const ball = createSphere(position, 1, Jolt.EMotionType_Dynamic, LAYER_MOVING, 0xFF0000);
-        const ballID = ball.GetID().GetIndexAndSequenceNumber();
+				const ballID = ball.GetID().GetIndexAndSequenceNumber();
 
 				const contactListener = new Jolt.ContactListenerJS();
 
-        size.Set(5.5,4.5,1.5);
-        position.Set(5.5, -2, -15);
-        const movingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1111FF);
-        const movingWaterID = movingWater.GetID().GetIndexAndSequenceNumber();
-        const waterThreeModel = dynamicObjects[dynamicObjects.length - 1];
-        waterThreeModel.material.wireframe = true;
-        
-        size.Set(7.5,2,1.5);
-        position.Set(-7.5, -8.5, -15);
-        const standingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1133FF);
-        const standingWaterID = standingWater.GetID().GetIndexAndSequenceNumber();
-        const standingThreeModel = dynamicObjects[dynamicObjects.length - 1];
-        standingThreeModel.material.wireframe = true;
+				size.Set(5.5, 4.5, 1.5);
+				position.Set(5.5, -2, -15);
+				const movingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1111FF);
+				const movingWaterID = movingWater.GetID().GetIndexAndSequenceNumber();
+				const waterThreeModel = dynamicObjects[dynamicObjects.length - 1];
+				waterThreeModel.material.wireframe = true;
 
+				size.Set(7.5, 2, 1.5);
+				position.Set(-7.5, -8.5, -15);
+				const standingWater = createSensorBox(position, ident, size, Jolt.EMotionType_Static, LAYER_NON_MOVING, 0x1133FF);
+				const standingWaterID = standingWater.GetID().GetIndexAndSequenceNumber();
+				const standingThreeModel = dynamicObjects[dynamicObjects.length - 1];
+				standingThreeModel.material.wireframe = true;
 
-        const inBuoyancy = 1.1;
-        const inLinearDrag = 0.3;
-        const inAngularDrag = 0.05;
-        const inSurfaceNormal = new Jolt.Vec3(0, 1, 0);
-        const inGravity = new Jolt.Vec3(0, -9.8, 0);
+				const inBuoyancy = 1.1;
+				const inLinearDrag = 0.3;
+				const inAngularDrag = 0.05;
+				const inSurfaceNormal = new Jolt.Vec3(0, 1, 0);
+				const inGravity = new Jolt.Vec3(0, -9.8, 0);
 
-        const inMovingFluidVelocity = new Jolt.Vec3(-0.5, 0, 0);
-        const inMovingWaterSurfacePosition = new Jolt.Vec3(0, 2.5, 0);
+				const inMovingFluidVelocity = new Jolt.Vec3(-0.5, 0, 0);
+				const inMovingWaterSurfacePosition = new Jolt.Vec3(0, 2.5, 0);
 
-        const inStandingWaterSurfacePosition = new Jolt.Vec3(0, -6.5, 0);
-        const inNoFluidVelocity = new Jolt.Vec3(0, 0, 0);
+				const inStandingWaterSurfacePosition = new Jolt.Vec3(0, -6.5, 0);
+				const inNoFluidVelocity = new Jolt.Vec3(0, 0, 0);
 
-        let inDeltaTime = 1/60;
+				let inDeltaTime = 1 / 60;
 
-        function OnContact(body1, body2, manifold, settings) {
+				function OnContact(body1, body2, manifold, settings) {
 					body1 = Jolt.wrapPointer(body1, Jolt.Body);
 					body2 = Jolt.wrapPointer(body2, Jolt.Body);
-          const body1ID = body1.GetID().GetIndexAndSequenceNumber();
-          const body2ID = body2.GetID().GetIndexAndSequenceNumber();
-          if (body1ID == ballID || body2ID == ballID) {
-            if (body1ID == movingWaterID || body2ID == movingWaterID) {
-              ball.ApplyBuoyancyImpulse(inMovingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inMovingFluidVelocity, inGravity, inDeltaTime);
-            }
-            if (body1ID == standingWaterID || body2ID == standingWaterID) {
-            ball.ApplyBuoyancyImpulse(inStandingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inNoFluidVelocity, inGravity, inDeltaTime);
-            }
-          }
-          
-        }
+					const body1ID = body1.GetID().GetIndexAndSequenceNumber();
+					const body2ID = body2.GetID().GetIndexAndSequenceNumber();
+					if (body1ID == ballID || body2ID == ballID) {
+						if (body1ID == movingWaterID || body2ID == movingWaterID) {
+							ball.ApplyBuoyancyImpulse(inMovingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inMovingFluidVelocity, inGravity, inDeltaTime);
+						}
+						if (body1ID == standingWaterID || body2ID == standingWaterID) {
+							ball.ApplyBuoyancyImpulse(inStandingWaterSurfacePosition, inSurfaceNormal, inBuoyancy, inLinearDrag, inAngularDrag, inNoFluidVelocity, inGravity, inDeltaTime);
+						}
+					}
+
+				}
 
 				contactListener.OnContactAdded = OnContact;
 				contactListener.OnContactPersisted = OnContact;
-
-        contactListener.OnContactValidate = (body1, body2, baseOffset, collideShapeResult) => {
+				contactListener.OnContactValidate = (body1, body2, baseOffset, collideShapeResult) => {
 					return Jolt.ValidateResult_AcceptAllContactsForThisBodyPair;
 				};
-				contactListener.OnContactRemoved = (subShapePair) => {};
+				contactListener.OnContactRemoved = (subShapePair) => { };
 				physicsSystem.SetContactListener(contactListener);
 
-        onExampleUpdate = function (time, deltaTime) {
-          inDeltaTime = deltaTime; 
-        }
-
+				onExampleUpdate = function (time, deltaTime) {
+					inDeltaTime = deltaTime;
+				}
 			});
-
 		</script>
 	</body>
 </html>

--- a/Examples/buoyancy.html
+++ b/Examples/buoyancy.html
@@ -9,7 +9,7 @@
 
 	<body>
 		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js bouyancy demo<br />
+		<div id="info">JoltPhysics.js buoyancy demo<br />
 		</div>
 
 		<script src="js/three/three.min.js"></script>

--- a/Examples/heightfield.html
+++ b/Examples/heightfield.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="style.css">
+    <style>
+      #sampleImg {
+        position: absolute;
+        width: 256px;
+        height: 256px;
+        top: 0;
+        right: 0;
+      }
+      #canvas {
+        position: absolute;
+        top: 256px;
+        right: 0;
+      }
+    </style>
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js heightfield demo<br/>
+		</div>
+
+		<script src="js/three/three.min.js"></script>
+		<script src="js/three/OrbitControls.js"></script>
+		<script src="js/three/WebGL.js"></script>
+		<script src="js/three/stats.min.js"></script>
+		<script src="js/example.js"></script>
+
+    <svg id="sampleImg" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 256 256">
+      <defs>
+          <filter id="turbulenceFilter">
+              <feTurbulence
+                type="fractalNoise"
+                baseFrequency=".02"
+                numOctaves="3"
+                seed="5"
+                result="turbulence" />
+          <feColorMatrix
+                in="turbulence"
+                type="matrix"
+                result="grayscale"
+                values=".33 .33 .33 0 0
+                        .33 .33 .33 0 0
+                        .33 .33 .33 0 0
+                        0 0 0 1 0" />
+              <feComposite operator="in" in="grayscale" in2="SourceGraphic"/>
+              <feComponentTransfer color-interpolation-filters="sRGB">
+                    <feFuncR type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncR>
+                    <feFuncG type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncG>
+                    <feFuncB type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncB>
+              </feComponentTransfer>
+          </filter>
+      </defs>
+      <rect x="0" y="0" width="256" height="256" filter="url(#turbulenceFilter)"></rect>
+      <text x="64" y="96" style="font-weight: bold; font-size:52px; fill: #fff">JOLT</text>
+      <text x="16" y="168" style="font-weight: bold; font-size:52px; fill: #fff">PHYSICS</text>
+    </svg>
+    <canvas style="display: none" id="canvas" width="256" height="256"></canvas>
+
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from './js/jolt-physics.wasm-compat.js';
+
+      function getGrayscaleData(img) {
+          const canvas = document.getElementById('canvas');
+          canvas.width = img.width;
+          canvas.height = img.width;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0);
+          const imgData = ctx.getImageData(0,0,canvas.width, canvas.height);
+          const f32 = new Float32Array(canvas.width * canvas.height);
+          f32.forEach((o,i) => {
+            f32[i] = imgData.data[i*4]; // reading only red channel
+            if(imgData.data[i*4+3] == 0) {
+              f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue;
+            }
+          });
+          return {img, data: f32};
+      }
+      function allocF32(len) {
+        const floatPtr = Jolt._webidl_malloc(4 * len);
+        const floatPtrRef = Jolt.wrapPointer(floatPtr, Jolt.FloatMemRef);
+        const f32Array = new Float32Array(Jolt.HEAPF32.buffer, floatPtr, len);
+        return {
+          ref: floatPtrRef,
+          array: f32Array
+        }
+      }
+
+      function heightFieldFromSVGl(svg, x, z) {
+        const heightmap = getGrayscaleData(svg);
+        const f32Array = allocF32(heightmap.data.length);
+        f32Array.array.set(heightmap.data);
+
+        const inOffset = new Jolt.Vec3(-heightmap.img.width*1.5/2, 0, -heightmap.img.height*1.5/2);
+        const inScale = new Jolt.Vec3(1, 0.1, 1);
+
+        const shapeSettings = new Jolt.HeightFieldShapeSettings(f32Array.ref, inOffset, inScale, heightmap.img.width);
+        shapeSettings.mBlockSize=2;
+        let shape = shapeSettings.Create().Get();
+        const position = new Jolt.Vec3(x, -20, z);
+        const rotation = new Jolt.Quat(0, 0, 0, 1)
+        var creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, Jolt.EBodyType_Static, LAYER_NON_MOVING);
+        let body = bodyInterface.CreateBody(creationSettings);
+        Jolt.destroy(creationSettings);
+        return body;
+      }
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+        const img = new Image();
+        img.width = 128;
+        img.height = 128;
+        img.src='data:image/svg+xml;base64,'+btoa(document.querySelector('svg').outerHTML);
+        await new Promise(resolve => img.onload=resolve);
+        const terrain = heightFieldFromSVGl(img, 32, 32);
+
+				addToScene(terrain, 0xaaaaaa);
+
+        const position = new Jolt.Vec3(0, 0, 0);
+        for(let y=0;y<10;y++)
+        for(let x=0;x<10;x++) {
+          const px = -31 + x * 62 / 10;
+          const py = -31 + y * 62 / 10; 
+          position.Set(px, 20, py);
+          createSphere(position, 1, Jolt.EMotionType_Dynamic, LAYER_MOVING, 0xFF0000);
+        }
+			});
+
+		</script>
+	</body>
+</html>

--- a/Examples/heightfield.html
+++ b/Examples/heightfield.html
@@ -13,12 +13,6 @@
 				top: 0;
 				right: 0;
 			}
-
-			#canvas {
-				position: absolute;
-				top: 256px;
-				right: 0;
-			}
 		</style>
 	</head>
 
@@ -53,6 +47,7 @@
 			<text x="64" y="96" style="font-weight: bold; font-size:52px; fill: #f0f">JOLT</text>
 			<text x="16" y="168" style="font-weight: bold; font-size:52px; fill: #ff0">PHYSICS</text>
 		</svg>
+		<!-- used for both the extraction of image-data to a height map, and for the CanvasTexture used to render the displacement map on the THREE side -->
 		<canvas style="display: none" id="canvas" width="256" height="256"></canvas>
 
 
@@ -69,13 +64,16 @@
 				const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 				const f32 = new Float32Array(canvas.width * canvas.height);
 				f32.forEach((o, i) => {
-					f32[i] = imgData.data[i * 4]; // reading only red channel
+					f32[i] = imgData.data[i * 4]; // reading only red channel for height
 					if (imgData.data[i * 4 + 3] == 0) {
-						f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue;
+						f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue; //invisible pixels make holes
 					}
 				});
 				return { img, data: f32 };
 			}
+
+			// Malloc a block of memory. Reference it in the Jolt HEAP for use on the JS side as a F32 ArrayBuffer
+			// Wrap it as a typed Jolt pointer for Typing and type-safety in Typescript 
 			function allocF32(len) {
 				const floatPtr = Jolt._webidl_malloc(4 * len);
 				const floatPtrRef = Jolt.wrapPointer(floatPtr, Jolt.FloatMemRef);
@@ -99,7 +97,7 @@
 				const shapeSettings = new Jolt.HeightFieldShapeSettings(f32Array.ref, inOffset, inScale, heightmap.img.width);
 				shapeSettings.mBlockSize = 2;
 				let shape = shapeSettings.Create().Get();
-				const position = new Jolt.Vec3(x, -20, z);
+				const position = new Jolt.Vec3(x, -20, z); //The image tends towards 'white', so offset it down closer to zero
 				const rotation = new Jolt.Quat(0, 0, 0, 1)
 				var creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, Jolt.EBodyType_Static, LAYER_NON_MOVING);
 				let body = bodyInterface.CreateBody(creationSettings);
@@ -124,12 +122,12 @@
 					new THREE.MeshPhongMaterial({
 						displacementMap: displacementMap,
 						map: displacementMap,
-						displacementScale: 256 / 10,
+						displacementScale: 256 * 0.1, //This should match the Y multiplier used on the ShapeSettings inScale.
 						flatShading: true
 					})
 				);
 				planeMesh.rotation.x = -Math.PI / 2;
-				planeMesh.position.y -= 20;
+				planeMesh.position.y -= 20; // mirror the same Y offset used on the HeightField above
 				planeMesh.geometry.computeVertexNormals();
 				planeMesh.material.needsUpdate = true;
 

--- a/Examples/heightfield.html
+++ b/Examples/heightfield.html
@@ -5,24 +5,26 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link rel="stylesheet" type="text/css" href="style.css">
-    <style>
-      #sampleImg {
-        position: absolute;
-        width: 256px;
-        height: 256px;
-        top: 0;
-        right: 0;
-      }
-      #canvas {
-        position: absolute;
-        top: 256px;
-        right: 0;
-      }
-    </style>
+		<style>
+			#sampleImg {
+				position: absolute;
+				width: 256px;
+				height: 256px;
+				top: 0;
+				right: 0;
+			}
+
+			#canvas {
+				position: absolute;
+				top: 256px;
+				right: 0;
+			}
+		</style>
 	</head>
+
 	<body>
 		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js heightfield demo<br/>
+		<div id="info">JoltPhysics.js heightfield demo<br />
 		</div>
 
 		<script src="js/three/three.min.js"></script>
@@ -31,107 +33,117 @@
 		<script src="js/three/stats.min.js"></script>
 		<script src="js/example.js"></script>
 
-    <svg id="sampleImg" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 256 256">
-      <defs>
-          <filter id="turbulenceFilter">
-              <feTurbulence
-                type="fractalNoise"
-                baseFrequency=".02"
-                numOctaves="3"
-                seed="5"
-                result="turbulence" />
-          <feColorMatrix
-                in="turbulence"
-                type="matrix"
-                result="grayscale"
-                values=".33 .33 .33 0 0
-                        .33 .33 .33 0 0
-                        .33 .33 .33 0 0
-                        0 0 0 1 0" />
-              <feComposite operator="in" in="grayscale" in2="SourceGraphic"/>
-              <feComponentTransfer color-interpolation-filters="sRGB">
-                    <feFuncR type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncR>
-                    <feFuncG type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncG>
-                    <feFuncB type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncB>
-              </feComponentTransfer>
-          </filter>
-      </defs>
-      <rect x="0" y="0" width="256" height="256" filter="url(#turbulenceFilter)"></rect>
-      <text x="64" y="96" style="font-weight: bold; font-size:52px; fill: #fff">JOLT</text>
-      <text x="16" y="168" style="font-weight: bold; font-size:52px; fill: #fff">PHYSICS</text>
-    </svg>
-    <canvas style="display: none" id="canvas" width="256" height="256"></canvas>
+		<svg id="sampleImg" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 256 256">
+			<defs>
+				<filter id="turbulenceFilter">
+					<feTurbulence type="fractalNoise" baseFrequency=".02" numOctaves="3" seed="5" result="turbulence" />
+					<feColorMatrix in="turbulence" type="matrix" result="grayscale" values=".33 .33 .33 0 0
+													.33 .33 .33 0 0
+													.33 .33 .33 0 0
+													0 0 0 1 0" />
+					<feComposite operator="in" in="grayscale" in2="SourceGraphic" />
+					<feComponentTransfer color-interpolation-filters="sRGB">
+						<feFuncR type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncR>
+						<feFuncG type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncG>
+						<feFuncB type="gamma" exponent="1.5" amplitude="1.3" offset="0"></feFuncB>
+					</feComponentTransfer>
+				</filter>
+			</defs>
+			<rect x="0" y="0" width="256" height="256" filter="url(#turbulenceFilter)"></rect>
+			<text x="64" y="96" style="font-weight: bold; font-size:52px; fill: #f0f">JOLT</text>
+			<text x="16" y="168" style="font-weight: bold; font-size:52px; fill: #ff0">PHYSICS</text>
+		</svg>
+		<canvas style="display: none" id="canvas" width="256" height="256"></canvas>
 
 
 		<script type="module">
 			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
 			import initJolt from './js/jolt-physics.wasm-compat.js';
 
-      function getGrayscaleData(img) {
-          const canvas = document.getElementById('canvas');
-          canvas.width = img.width;
-          canvas.height = img.width;
-          const ctx = canvas.getContext('2d');
-          ctx.drawImage(img, 0, 0);
-          const imgData = ctx.getImageData(0,0,canvas.width, canvas.height);
-          const f32 = new Float32Array(canvas.width * canvas.height);
-          f32.forEach((o,i) => {
-            f32[i] = imgData.data[i*4]; // reading only red channel
-            if(imgData.data[i*4+3] == 0) {
-              f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue;
-            }
-          });
-          return {img, data: f32};
-      }
-      function allocF32(len) {
-        const floatPtr = Jolt._webidl_malloc(4 * len);
-        const floatPtrRef = Jolt.wrapPointer(floatPtr, Jolt.FloatMemRef);
-        const f32Array = new Float32Array(Jolt.HEAPF32.buffer, floatPtr, len);
-        return {
-          ref: floatPtrRef,
-          array: f32Array
-        }
-      }
+			function getGrayscaleData(img) {
+				const canvas = document.getElementById('canvas');
+				canvas.width = img.width;
+				canvas.height = img.width;
+				const ctx = canvas.getContext('2d');
+				ctx.drawImage(img, 0, 0);
+				const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+				const f32 = new Float32Array(canvas.width * canvas.height);
+				f32.forEach((o, i) => {
+					f32[i] = imgData.data[i * 4]; // reading only red channel
+					if (imgData.data[i * 4 + 3] == 0) {
+						f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue;
+					}
+				});
+				return { img, data: f32 };
+			}
+			function allocF32(len) {
+				const floatPtr = Jolt._webidl_malloc(4 * len);
+				const floatPtrRef = Jolt.wrapPointer(floatPtr, Jolt.FloatMemRef);
+				const f32Array = new Float32Array(Jolt.HEAPF32.buffer, floatPtr, len);
+				return {
+					ref: floatPtrRef,
+					array: f32Array
+				}
+			}
 
-      function heightFieldFromSVGl(svg, x, z) {
-        const heightmap = getGrayscaleData(svg);
-        const f32Array = allocF32(heightmap.data.length);
-        f32Array.array.set(heightmap.data);
+			const mapScale = 0.35;
 
-        const inOffset = new Jolt.Vec3(-heightmap.img.width*1.5/2, 0, -heightmap.img.height*1.5/2);
-        const inScale = new Jolt.Vec3(1, 0.1, 1);
+			function heightFieldFromSVGl(svg, x, z) {
+				const heightmap = getGrayscaleData(svg);
+				const f32Array = allocF32(heightmap.data.length);
+				f32Array.array.set(heightmap.data);
 
-        const shapeSettings = new Jolt.HeightFieldShapeSettings(f32Array.ref, inOffset, inScale, heightmap.img.width);
-        shapeSettings.mBlockSize=2;
-        let shape = shapeSettings.Create().Get();
-        const position = new Jolt.Vec3(x, -20, z);
-        const rotation = new Jolt.Quat(0, 0, 0, 1)
-        var creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, Jolt.EBodyType_Static, LAYER_NON_MOVING);
-        let body = bodyInterface.CreateBody(creationSettings);
-        Jolt.destroy(creationSettings);
-        return body;
-      }
+				const inOffset = new Jolt.Vec3(0, 0, 0);
+				const inScale = new Jolt.Vec3(mapScale, 0.1, mapScale);
+
+				const shapeSettings = new Jolt.HeightFieldShapeSettings(f32Array.ref, inOffset, inScale, heightmap.img.width);
+				shapeSettings.mBlockSize = 2;
+				let shape = shapeSettings.Create().Get();
+				const position = new Jolt.Vec3(x, -20, z);
+				const rotation = new Jolt.Quat(0, 0, 0, 1)
+				var creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, Jolt.EBodyType_Static, LAYER_NON_MOVING);
+				let body = bodyInterface.CreateBody(creationSettings);
+				Jolt.destroy(creationSettings);
+				return body;
+			}
 
 			initJolt().then(async function (Jolt) {
 				// Initialize this example
 				initExample(Jolt, null);
-        const img = new Image();
-        img.width = 128;
-        img.height = 128;
-        img.src='data:image/svg+xml;base64,'+btoa(document.querySelector('svg').outerHTML);
-        await new Promise(resolve => img.onload=resolve);
-        const terrain = heightFieldFromSVGl(img, 32, 32);
+				const img = new Image();
+				img.width = 256;
+				img.height = 256;
+				img.src = 'data:image/svg+xml;base64,' + btoa(document.querySelector('svg').outerHTML);
+				await new Promise(resolve => img.onload = resolve);
+				const terrain = heightFieldFromSVGl(img, -img.width * mapScale / 2, -img.width * mapScale / 2);
 
-				addToScene(terrain, 0xaaaaaa);
+				const displacementMap = new THREE.CanvasTexture(document.getElementById('canvas'));
+				// creating the plane with displacement
+				const planeMesh = new THREE.Mesh(
+					new THREE.PlaneGeometry(img.width * mapScale, img.width * mapScale, 256, 256),
+					new THREE.MeshPhongMaterial({
+						displacementMap: displacementMap,
+						map: displacementMap,
+						displacementScale: 256 / 10,
+						flatShading: true
+					})
+				);
+				planeMesh.rotation.x = -Math.PI / 2;
+				planeMesh.position.y -= 20;
+				planeMesh.geometry.computeVertexNormals();
+				planeMesh.material.needsUpdate = true;
 
-        const position = new Jolt.Vec3(0, 0, 0);
-        for(let y=0;y<10;y++)
-        for(let x=0;x<10;x++) {
-          const px = -31 + x * 62 / 10;
-          const py = -31 + y * 62 / 10; 
-          position.Set(px, 20, py);
-          createSphere(position, 1, Jolt.EMotionType_Dynamic, LAYER_MOVING, 0xFF0000);
-        }
+				bodyInterface.AddBody(terrain.GetID(), Jolt.EActivation_Activate);
+				scene.add(planeMesh);
+
+				const position = new Jolt.Vec3(0, 0, 0);
+				for (let y = 0; y < 10; y++)
+					for (let x = 0; x < 10; x++) {
+						const px = -31 + x * 62 / 10;
+						const py = -31 + y * 62 / 10;
+						position.Set(px, 20, py);
+						createSphere(position, 1, Jolt.EMotionType_Dynamic, LAYER_MOVING, 0xFF0000);
+					}
 			});
 
 		</script>

--- a/Examples/heightfield.html
+++ b/Examples/heightfield.html
@@ -55,49 +55,35 @@
 			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
 			import initJolt from './js/jolt-physics.wasm-compat.js';
 
-			function getGrayscaleData(img) {
-				const canvas = document.getElementById('canvas');
-				canvas.width = img.width;
-				canvas.height = img.width;
-				const ctx = canvas.getContext('2d');
-				ctx.drawImage(img, 0, 0);
-				const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-				const f32 = new Float32Array(canvas.width * canvas.height);
-				f32.forEach((o, i) => {
-					f32[i] = imgData.data[i * 4]; // reading only red channel for height
-					if (imgData.data[i * 4 + 3] == 0) {
-						f32[i] = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue; //invisible pixels make holes
-					}
-				});
-				return { img, data: f32 };
-			}
-
-			// Malloc a block of memory. Reference it in the Jolt HEAP for use on the JS side as a F32 ArrayBuffer
-			// Wrap it as a typed Jolt pointer for Typing and type-safety in Typescript 
-			function allocF32(len) {
-				const floatPtr = Jolt._webidl_malloc(4 * len);
-				const floatPtrRef = Jolt.wrapPointer(floatPtr, Jolt.FloatMemRef);
-				const f32Array = new Float32Array(Jolt.HEAPF32.buffer, floatPtr, len);
-				return {
-					ref: floatPtrRef,
-					array: f32Array
-				}
-			}
-
 			const mapScale = 0.35;
 
 			function heightFieldFromSVGl(svg, x, z) {
-				const heightmap = getGrayscaleData(svg);
-				const f32Array = allocF32(heightmap.data.length);
-				f32Array.array.set(heightmap.data);
+				// Draw the SVG to a canvas, and extract the image data
+				const canvas = document.getElementById('canvas');
+				canvas.width = svg.width;
+				canvas.height = svg.width;
+				const ctx = canvas.getContext('2d');
+				ctx.drawImage(svg, 0, 0);
+				const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
-				const inOffset = new Jolt.Vec3(0, 0, 0);
-				const inScale = new Jolt.Vec3(mapScale, 0.1, mapScale);
-
-				const shapeSettings = new Jolt.HeightFieldShapeSettings(f32Array.ref, inOffset, inScale, heightmap.img.width);
+				// Create the heightfield
+				const shapeSettings = new Jolt.HeightFieldShapeSettings();
+				shapeSettings.mOffset = new Jolt.Vec3(0, 0, 0);
+				shapeSettings.mScale = new Jolt.Vec3(mapScale, 0.1, mapScale);
+				shapeSettings.mSampleCount = canvas.width;
 				shapeSettings.mBlockSize = 2;
+				const totalSize = canvas.width * canvas.height;
+				shapeSettings.mHeightSamples.reserve(totalSize);
+				for (let i = 0; i < totalSize; i++) {
+					let height = imgData.data[i * 4]; // Reading only red channel for height
+					if (imgData.data[i * 4 + 3] == 0)
+						height = Jolt.HeightFieldShapeConstantValues.prototype.cNoCollisionValue; // Invisible pixels make holes
+					shapeSettings.mHeightSamples.push_back(height);
+				}
 				let shape = shapeSettings.Create().Get();
-				const position = new Jolt.Vec3(x, -20, z); //The image tends towards 'white', so offset it down closer to zero
+
+				// Create the body
+				const position = new Jolt.Vec3(x, -20, z); // The image tends towards 'white', so offset it down closer to zero
 				const rotation = new Jolt.Quat(0, 0, 0, 1)
 				var creationSettings = new Jolt.BodyCreationSettings(shape, position, rotation, Jolt.EBodyType_Static, LAYER_NON_MOVING);
 				let body = bodyInterface.CreateBody(creationSettings);
@@ -116,18 +102,18 @@
 				const terrain = heightFieldFromSVGl(img, -img.width * mapScale / 2, -img.width * mapScale / 2);
 
 				const displacementMap = new THREE.CanvasTexture(document.getElementById('canvas'));
-				// creating the plane with displacement
+				// Creating the plane with displacement
 				const planeMesh = new THREE.Mesh(
 					new THREE.PlaneGeometry(img.width * mapScale, img.width * mapScale, 256, 256),
 					new THREE.MeshPhongMaterial({
 						displacementMap: displacementMap,
 						map: displacementMap,
-						displacementScale: 256 * 0.1, //This should match the Y multiplier used on the ShapeSettings inScale.
+						displacementScale: 256 * 0.1, // This should match the Y multiplier used on the ShapeSettings inScale.
 						flatShading: true
 					})
 				);
 				planeMesh.rotation.x = -Math.PI / 2;
-				planeMesh.position.y -= 20; // mirror the same Y offset used on the HeightField above
+				planeMesh.position.y -= 20; // Mirror the same Y offset used on the HeightField above
 				planeMesh.geometry.computeVertexNormals();
 				planeMesh.material.needsUpdate = true;
 

--- a/Examples/index.html
+++ b/Examples/index.html
@@ -23,6 +23,8 @@
 			<li><a href="snapshot.html">Snapshot Demo</a> - Shows how to snapshot and restore the simulation</li>
 			<li><a href="ray_cast.html">Ray Cast Demo</a> - Shows how to do a ray cast</li>
 			<li><a href="proper_cleanup.html">Proper Cleanup Demo</a> - Shows how to clean up memory</li>
+			<li><a href="buoyancy.html">Buoyancy Demo</a> - Shows moving and static fluids and their ability to influence bodies</li>
+			<li><a href="heightfield.html">Height Field Shape Demo</a> - Shows support for loading of height fields as collision surfaces</li>
 		</ul>
 	</body>
 </html>

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -237,7 +237,6 @@ static void TraceImpl(const char *inFMT, ...)
 	cout << buffer << endl;
 }
 
-
 #ifdef JPH_ENABLE_ASSERTS
 
 // Callback for asserts
@@ -481,20 +480,9 @@ private:
 	VehicleConstraint *		mInstance;
 };
 
-class HeightFieldShapeConstantValues {
-	public:
-			/// Value used to create gaps in the height field
-		static constexpr float	cNoCollisionValue = HeightFieldShapeConstants::cNoCollisionValue;
-
-		/// Stack size to use during WalkHeightField
-		static constexpr int cStackSize  = HeightFieldShapeConstants::cStackSize;
-
-		/// A position in the hierarchical grid is defined by a level (which grid), x and y position. We encode this in a single uint32 as: level << 28 | y << 14 | x
-		static constexpr uint cNumBitsXY = HeightFieldShapeConstants::cNumBitsXY;
-		static constexpr uint cMaskBitsXY = HeightFieldShapeConstants::cMaskBitsXY;
-		static constexpr uint cLevelShift = HeightFieldShapeConstants::cLevelShift;
-
-		/// When height samples are converted to 16 bit:
-		static constexpr uint16 cNoCollisionValue16 = HeightFieldShapeConstants::cNoCollisionValue16;
-		static constexpr uint16 cMaxHeightValue16 = HeightFieldShapeConstants::cMaxHeightValue16;
+class HeightFieldShapeConstantValues 
+{
+public:
+	/// Value used to create gaps in the height field
+	static constexpr float	cNoCollisionValue = HeightFieldShapeConstants::cNoCollisionValue;
 };

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -26,6 +26,7 @@
 #include "Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h"
 #include "Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h"
 #include "Jolt/Physics/Collision/Shape/MeshShape.h"
+#include "Jolt/Physics/Collision/Shape/HeightFieldShape.h"
 #include "Jolt/Physics/Collision/CollisionCollectorImpl.h"
 #include "Jolt/Physics/Collision/GroupFilterTable.h"
 #include "Jolt/Physics/Collision/CollideShape.h"
@@ -58,6 +59,9 @@ using JPHString = String;
 using ArrayVec3 = Array<Vec3>;
 using ArrayFloat = Array<float>;
 using ArrayLong = Array<uint>;
+using ArrayUint8 = Array<uint8>;
+using FloatMemRef = float;
+using Uint8MemRef = uint8;
 using SoftBodySharedSettingsVertex = SoftBodySharedSettings::Vertex;
 using SoftBodySharedSettingsFace = SoftBodySharedSettings::Face;
 using SoftBodySharedSettingsEdge = SoftBodySharedSettings::Edge;
@@ -232,6 +236,7 @@ static void TraceImpl(const char *inFMT, ...)
 	// Print to the TTY
 	cout << buffer << endl;
 }
+
 
 #ifdef JPH_ENABLE_ASSERTS
 
@@ -474,4 +479,22 @@ public:
 
 private:
 	VehicleConstraint *		mInstance;
+};
+
+class HeightFieldShapeConstantValues {
+	public:
+			/// Value used to create gaps in the height field
+		static constexpr float	cNoCollisionValue = HeightFieldShapeConstants::cNoCollisionValue;
+
+		/// Stack size to use during WalkHeightField
+		static constexpr int cStackSize  = HeightFieldShapeConstants::cStackSize;
+
+		/// A position in the hierarchical grid is defined by a level (which grid), x and y position. We encode this in a single uint32 as: level << 28 | y << 14 | x
+		static constexpr uint cNumBitsXY = HeightFieldShapeConstants::cNumBitsXY;
+		static constexpr uint cMaskBitsXY = HeightFieldShapeConstants::cMaskBitsXY;
+		static constexpr uint cLevelShift = HeightFieldShapeConstants::cLevelShift;
+
+		/// When height samples are converted to 16 bit:
+		static constexpr uint16 cNoCollisionValue16 = HeightFieldShapeConstants::cNoCollisionValue16;
+		static constexpr uint16 cMaxHeightValue16 = HeightFieldShapeConstants::cMaxHeightValue16;
 };

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -167,9 +167,11 @@ enum ETransmissionMode {
 	"ETransmissionMode_Manual",
 };
 
+interface FloatMemRef {
+};
 
-interface FloatMemRef {};
-interface Uint8MemRef {};
+interface Uint8MemRef {
+};
 
 interface Vec3 {
 	void Vec3();
@@ -752,22 +754,13 @@ interface MeshShape {
 
 MeshShape implements Shape;
 
-
 interface HeightFieldShapeConstantValues {
-		[Const] static readonly attribute float	cNoCollisionValue;
-
-		[Const] static readonly attribute long cStackSize;
-
-		[Const] static readonly attribute long cNumBitsXY;
-		[Const] static readonly attribute long cMaskBitsXY;
-		[Const] static readonly attribute long cLevelShift;
-
-		[Const] static readonly attribute long cNoCollisionValue16;
-		[Const] static readonly attribute long cMaxHeightValue16;
+	[Const] static readonly attribute float	cNoCollisionValue;
 };
 
 interface HeightFieldShapeSettings {
-	void HeightFieldShapeSettings( [Const] FloatMemRef inSamples, [Ref] Vec3 inOffset, [Ref] Vec3 inscale, long inSampleCount, [Const] optional Uint8MemRef inMaterialIndices, [Ref, Const] optional PhysicsMaterialList inMaterialList);
+	void HeightFieldShapeSettings();
+
 	[Value] attribute Vec3 mOffset;
 	[Value] attribute Vec3 mScale;
 	attribute long mSampleCount;
@@ -780,6 +773,7 @@ interface HeightFieldShapeSettings {
 	[Value] attribute PhysicsMaterialList mMaterials;
 	attribute float mActiveEdgeCosThresholdAngle;
 };
+
 HeightFieldShapeSettings implements ShapeSettings;
 
 interface HeightFieldShape {
@@ -1249,7 +1243,7 @@ interface Body {
 	void AddImpulse([Const, Ref] Vec3 inImpulse, [Const, Ref] Vec3 inPosition);
 	void AddAngularImpulse([Const, Ref] Vec3 inAngularImpulse);
 	void MoveKinematic([Const, Ref] Vec3 inPosition, [Const, Ref] Quat inRotation, float inDeltaTime);
-	boolean ApplyBuoyancyImpulse([Ref] Vec3 inSurfacePosition, [Ref] Vec3 inSurfaceNormal, float inBuoyancy, float inLinearDrag, float inAngularDrag, [Ref] Vec3 inFluidVelocity, [Ref] Vec3 inGravity, float inDeltaTime);
+	boolean ApplyBuoyancyImpulse([Const, Ref] Vec3 inSurfacePosition, [Const, Ref] Vec3 inSurfaceNormal, float inBuoyancy, float inLinearDrag, float inAngularDrag, [Const, Ref] Vec3 inFluidVelocity, [Const, Ref] Vec3 inGravity, float inDeltaTime);
 	boolean IsInBroadPhase();
 	[Const, Value] Mat44 GetInverseInertia();
 	[Const] Shape GetShape();
@@ -2228,10 +2222,11 @@ interface ArrayLong {
 	void resize(unsigned long inSize);
 	void clear();
 };
+
 interface ArrayUint8 {
 	boolean empty();
 	long size();
-	long at(long inIndex);
+	octet at(long inIndex);
 	void push_back(octet inValue);
 	void reserve(unsigned long inSize);
 	void resize(unsigned long inSize);

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -167,6 +167,10 @@ enum ETransmissionMode {
 	"ETransmissionMode_Manual",
 };
 
+
+interface FloatMemRef {};
+interface Uint8MemRef {};
+
 interface Vec3 {
 	void Vec3();
 	void Vec3([Const, Ref] Float3 inV);
@@ -718,6 +722,47 @@ interface MeshShape {
 
 MeshShape implements Shape;
 
+
+interface HeightFieldShapeConstantValues {
+		[Const] static readonly attribute float	cNoCollisionValue;
+
+		[Const] static readonly attribute long cStackSize;
+
+		[Const] static readonly attribute long cNumBitsXY;
+		[Const] static readonly attribute long cMaskBitsXY;
+		[Const] static readonly attribute long cLevelShift;
+
+		[Const] static readonly attribute long cNoCollisionValue16;
+		[Const] static readonly attribute long cMaxHeightValue16;
+};
+
+interface HeightFieldShapeSettings {
+	void HeightFieldShapeSettings( [Const] FloatMemRef inSamples, [Ref] Vec3 inOffset, [Ref] Vec3 inscale, long inSampleCount, [Const] optional Uint8MemRef inMaterialIndices, [Ref, Const] optional PhysicsMaterialList inMaterialList);
+	[Value] attribute Vec3 mOffset;
+	[Value] attribute Vec3 mScale;
+	attribute long mSampleCount;
+	attribute float mMinHeightValue;
+	attribute float mMaxHeightValue;
+	attribute long mBlockSize;
+	attribute long mBitsPerSample;
+	[Value] attribute ArrayFloat mHeightSamples;
+	[Value] attribute ArrayUint8 mMaterialIndices;
+	[Value] attribute PhysicsMaterialList mMaterials;
+	attribute float mActiveEdgeCosThresholdAngle;
+};
+HeightFieldShapeSettings implements ShapeSettings;
+
+interface HeightFieldShape {
+	long GetSampleCount();
+	long GetBlockSize();
+	[Value] Vec3 GetPosition(long inX, long inY);
+	boolean IsNoCollision(long inX, long inY);
+	void GetHeights(long inX, long inY, long inSizeX, long inSizeY, FloatMemRef outHeights, long inHeightsStride);
+	void SetHeights(long inX, long inY, long inSizeX, long inSizeY, FloatMemRef inHeights, long inHeightsStride, [Ref] TempAllocator inAllocator, optional float inActiveEdgeCosThresholdAngle);
+};
+
+HeightFieldShape implements Shape;
+
 // Constraint
 interface ConstraintSettings {
 	attribute boolean mEnabled;
@@ -1174,6 +1219,7 @@ interface Body {
 	void AddImpulse([Const, Ref] Vec3 inImpulse, [Const, Ref] Vec3 inPosition);
 	void AddAngularImpulse([Const, Ref] Vec3 inAngularImpulse);
 	void MoveKinematic([Const, Ref] Vec3 inPosition, [Const, Ref] Quat inRotation, float inDeltaTime);
+	boolean ApplyBuoyancyImpulse([Ref] Vec3 inSurfacePosition, [Ref] Vec3 inSurfaceNormal, float inBuoyancy, float inLinearDrag, float inAngularDrag, [Ref] Vec3 inFluidVelocity, [Ref] Vec3 inGravity, float inDeltaTime);
 	boolean IsInBroadPhase();
 	[Const, Value] Mat44 GetInverseInertia();
 	[Const] Shape GetShape();
@@ -2148,6 +2194,15 @@ interface ArrayLong {
 	long size();
 	long at(long inIndex);
 	void push_back(long inValue);
+	void reserve(unsigned long inSize);
+	void resize(unsigned long inSize);
+	void clear();
+};
+interface ArrayUint8 {
+	boolean empty();
+	long size();
+	long at(long inIndex);
+	void push_back(octet inValue);
 	void reserve(unsigned long inSize);
 	void resize(unsigned long inSize);
 	void clear();


### PR DESCRIPTION
If there is a cleaner way to map the Namespace'd [HeightFieldShapeConstants], that would be better than my static-const [HeightFieldShapeConstantValues] wrapper that I have in the Jolt.h file.

There is a ApplyBuoyancyImpulse on the Body class and demo as well, and I have not split it into its own branch. That can be delayed if that is more appropriate.

If there is a better image that is wanted for the HeightField terrain, it isn't hard to just change the text/colors of the SVG. The raw SVG that generates the map is in the HTML itself and uses the browser's native perlin-noise for terrain.

The built-in "Auto ThreeJS" shape generation is unable to handle the mesh produced from a higher-resolution HeightField using the default example.js code without lagging to 10-20fps on my machine, purely due to ThreeJS efficiency and not Jolt, so I instead used a parallel THREE displacement mapped plane, which can handle much higher resolution height map without similar lagging.

![2023-12-08-heightfield](https://github.com/jrouwe/JoltPhysics.js/assets/756488/174b9e31-896a-4a29-9f80-d18b8ed57117)
