### PR TITLE
Clear invalid props

### DIFF
--- a/Examples/vehicle_motorcycle.html
+++ b/Examples/vehicle_motorcycle.html
@@ -111,7 +111,6 @@
 			addToScene(motorcycleBody, 0xFF0000);
 
 			const vehicle = new Jolt.VehicleConstraintSettings();
-			vehicle.mDrawConstraintSize = 0.1;
 			vehicle.mMaxPitchRollAngle = maxPitchRollAngle;
 
 			const motorcycle = dynamicObjects[dynamicObjects.length - 1];

--- a/Examples/vehicle_tank.html
+++ b/Examples/vehicle_tank.html
@@ -111,7 +111,6 @@
 			addToScene(tankBody, 0xFF0000);
 
 			const vehicle = new Jolt.VehicleConstraintSettings();
-			vehicle.mDrawConstraintSize = 0.1;
 			vehicle.mMaxPitchRollAngle = maxPitchRollAngle;
 
 			const tank = dynamicObjects[dynamicObjects.length - 1];

--- a/Examples/vehicle_wheeled.html
+++ b/Examples/vehicle_wheeled.html
@@ -114,7 +114,6 @@
 
 			// Create vehicle constraint
 			const vehicle = new Jolt.VehicleConstraintSettings();
-			vehicle.mDrawConstraintSize = 0.1;
 			vehicle.mMaxPitchRollAngle = DegreesToRadians(60.0);
 			vehicle.mWheels.clear();
 			const mWheels = [];


### PR DESCRIPTION
The member `mDrawConstraintSize` of `VehicleConstraintSettings` is not valid for Wasm, as there is no debug renderer and it is not exposed in IDL.