### PR TITLE
Fix OOM crash in vehicle examples

### DIFF
--- a/Examples/vehicle_motorcycle.html
+++ b/Examples/vehicle_motorcycle.html
@@ -80,6 +80,9 @@
 			let wheelMaterial = new THREE.MeshPhongMaterial({ color: 0x666666 });
 			wheelMaterial.map = texture;
 
+			const wheelRight = new Jolt.Vec3(0, 1, 0);
+			const wheelUp = new Jolt.Vec3(1, 0, 0);
+
 			const createThreeWheel = (constraint, wheelIndex, body) => {
 				// Create wheel mesh
 				const joltWheel = constraint.GetWheel(wheelIndex);
@@ -89,7 +92,7 @@
 
 				// Function to update the orientation of the wheel
 				wheel.updateLocalTransform = () => {
-					let transform = constraint.GetWheelLocalTransform(wheelIndex, new Jolt.Vec3(0, 1, 0), new Jolt.Vec3(1, 0, 0));
+					let transform = constraint.GetWheelLocalTransform(wheelIndex, wheelRight, wheelUp);
 					wheel.position.copy(wrapVec3(transform.GetTranslation()));
 					wheel.quaternion.copy(wrapQuat(transform.GetRotation().GetQuaternion()));
 				};

--- a/Examples/vehicle_tank.html
+++ b/Examples/vehicle_tank.html
@@ -80,6 +80,9 @@
 			let wheelMaterial = new THREE.MeshPhongMaterial({ color: 0x666666 });
 			wheelMaterial.map = texture;
 
+			const wheelRight = new Jolt.Vec3(0, 1, 0);
+			const wheelUp = new Jolt.Vec3(1, 0, 0);			
+
 			const createThreeWheel = (constraint, wheelIndex, body) => {
 				// Create wheel mesh
 				const joltWheel = constraint.GetWheel(wheelIndex);
@@ -89,7 +92,7 @@
 
 				// Function to update the orientation of the wheel
 				wheel.updateLocalTransform = () => {
-					let transform = constraint.GetWheelLocalTransform(wheelIndex, new Jolt.Vec3(0, 1, 0), new Jolt.Vec3(1, 0, 0));
+					let transform = constraint.GetWheelLocalTransform(wheelIndex, wheelRight, wheelUp);
 					wheel.position.copy(wrapVec3(transform.GetTranslation()));
 					wheel.quaternion.copy(wrapQuat(transform.GetRotation().GetQuaternion()));
 				};

--- a/Examples/vehicle_wheeled.html
+++ b/Examples/vehicle_wheeled.html
@@ -73,6 +73,9 @@
 			let wheelMaterial = new THREE.MeshPhongMaterial({ color: 0x666666 });
 			wheelMaterial.map = texture;
 
+			const wheelRight = new Jolt.Vec3(0, 1, 0);
+			const wheelUp = new Jolt.Vec3(1, 0, 0);			
+
 			const createThreeWheel = (constraint, wheelIndex, body) => {
 				// Create wheel mesh
 				const joltWheel = constraint.GetWheel(wheelIndex);
@@ -82,7 +85,7 @@
 
 				// Function to update the orientation of the wheel
 				wheel.updateLocalTransform = () => {
-					let transform = constraint.GetWheelLocalTransform(wheelIndex, new Jolt.Vec3(0, 1, 0), new Jolt.Vec3(1, 0, 0));
+					let transform = constraint.GetWheelLocalTransform(wheelIndex, wheelRight, wheelUp);
 					wheel.position.copy(wrapVec3(transform.GetTranslation()));
 					wheel.quaternion.copy(wrapQuat(transform.GetRotation().GetQuaternion()));
 				};


### PR DESCRIPTION
Moved out the vector allocations from the update loop to avoid OOM crash after the app stays active for a few minutes.