### PR TITLE
Feature: Pulley and Path Constraints

### DIFF
--- a/Examples/character_virtual.html
+++ b/Examples/character_virtual.html
@@ -155,7 +155,7 @@
 			const prePhysicsUpdate = (deltaTime) => {
 				if (isInLava) {
 					// Teleport the user back to the origin if they fall off the platform
-					_tmpVec3.Set(0,10,0);
+					_tmpVec3.Set(0, 10, 0);
 					character.SetPosition(_tmpVec3);
 					isInLava = false;
 				}
@@ -164,14 +164,14 @@
 					updateSettings.mStickToFloorStepDown = Jolt.Vec3.prototype.sZero();
 				} else {
 					const vec = characterUp.clone().multiplyScalar(-updateSettings.mStickToFloorStepDown.Length());
-					updateSettings.mStickToFloorStepDown.Set(vec.x,vec.y,vec.z);
+					updateSettings.mStickToFloorStepDown.Set(vec.x, vec.y, vec.z);
 				}
 
 				if (!enableWalkStairs) {
 					updateSettings.mWalkStairsStepUp = Jolt.Vec3.prototype.sZero();
 				} else {
 					const vec = characterUp.clone().multiplyScalar(updateSettings.mWalkStairsStepUp.Length());
-					updateSettings.mWalkStairsStepUp.Set(vec.x,vec.y,vec.z);
+					updateSettings.mWalkStairsStepUp.Set(vec.x, vec.y, vec.z);
 				}
 				characterUp.multiplyScalar(-physicsSystem.GetGravity().Length());
 				character.ExtendedUpdate(deltaTime,

--- a/Examples/character_virtual.html
+++ b/Examples/character_virtual.html
@@ -151,10 +151,12 @@
 				}
 			}
 
+			const _tmpVec3 = new Jolt.Vec3();
 			const prePhysicsUpdate = (deltaTime) => {
 				if (isInLava) {
 					// Teleport the user back to the origin if they fall off the platform
-					character.SetPosition(new Jolt.Vec3(0, 10, 0));
+					_tmpVec3.Set(0,10,0);
+					character.SetPosition(_tmpVec3);
 					isInLava = false;
 				}
 				const characterUp = wrapVec3(character.GetUp());
@@ -162,14 +164,14 @@
 					updateSettings.mStickToFloorStepDown = Jolt.Vec3.prototype.sZero();
 				} else {
 					const vec = characterUp.clone().multiplyScalar(-updateSettings.mStickToFloorStepDown.Length());
-					updateSettings.mStickToFloorStepDown = unwrapVec3(vec);
+					updateSettings.mStickToFloorStepDown.Set(vec.x,vec.y,vec.z);
 				}
 
 				if (!enableWalkStairs) {
 					updateSettings.mWalkStairsStepUp = Jolt.Vec3.prototype.sZero();
 				} else {
 					const vec = characterUp.clone().multiplyScalar(updateSettings.mWalkStairsStepUp.Length());
-					updateSettings.mWalkStairsStepUp = unwrapVec3(vec);
+					updateSettings.mWalkStairsStepUp.Set(vec.x,vec.y,vec.z);
 				}
 				characterUp.multiplyScalar(-physicsSystem.GetGravity().Length());
 				character.ExtendedUpdate(deltaTime,
@@ -199,7 +201,8 @@
 					// While in air we allow sliding
 					allowSliding = true;
 				}
-				const characterUpRotation = Jolt.Quat.prototype.sEulerAngles(new Jolt.Vec3(upRotationX, 0, upRotationZ));
+				_tmpVec3.Set(upRotationX, 0, upRotationZ);
+				const characterUpRotation = Jolt.Quat.prototype.sEulerAngles(_tmpVec3);
 				character.SetUp(characterUpRotation.RotateAxisY());
 				character.SetRotation(characterUpRotation);
 				const upRotation = wrapQuat(characterUpRotation);
@@ -240,7 +243,8 @@
 					newVelocity.add(currentHorizontalVelocity);
 				}
 
-				character.SetLinearVelocity(unwrapVec3(newVelocity));
+				_tmpVec3.Set(newVelocity.x, newVelocity.y, newVelocity.z);
+				character.SetLinearVelocity(_tmpVec3);
 			}
 
 			const setCrouched = (crouched, forceUpdate) => {

--- a/Examples/constraint_path.html
+++ b/Examples/constraint_path.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js 2d path constraint demo<br/>
+			This demo shows the various constraint settings on Path RotationConstraintType<br />
+      <div style="font-weight: bold;background: rgba(0.2,0.2,0.2,0.2);display:inline-block;padding:10px">
+      <span style="color:red">Red: Free Constraint</span><br />
+      <span style="color:green">Green: Path-Tangent Constraint</span><br />
+      <span style="color:blue">Blue: Path-Normal Constraint</span><br />
+      <span style="color:magenta">Magenta: Path-Binormal Constraint</span><br />
+      <span style="color:yellow">Yellow: Path-Space Constraint</span><br />
+      <span style="color:cyan">Cyan: Fully Constrained to Body1</span></div>
+    </div>
+
+		<script src="js/three/three.min.js"></script>
+		<script src="js/three/OrbitControls.js"></script>
+		<script src="js/three/WebGL.js"></script>
+		<script src="js/three/stats.min.js"></script>
+		<script src="js/example.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from './js/jolt-physics.wasm-compat.js';
+
+      class Line3DMesh {
+        constructor(points, color) {
+          this._points = points;
+          const material = new THREE.LineBasicMaterial({ color });
+          const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints( points );
+          this._line = new THREE.Line( geometry, material ); 
+        }
+
+        update() {
+          this._geometry.setFromPoints(this._points);
+        }
+
+        getMesh() {
+          return this._line;
+        }
+      }
+
+      initJolt().then(function (Jolt) {
+
+				// Initialize this example
+        const updates = [];
+				initExample(Jolt, () => {
+          updates.forEach(func => func());
+        });
+
+				// Create a basic floor
+				createFloor();
+
+        const rotation = new Jolt.Quat.prototype.sIdentity();
+        const position = new Jolt.Vec3();
+        const size = new Jolt.Vec3(0.5,0.1,0.5);
+
+        const pathPoints = [];
+        const pointResolution = 100;
+        for(let i=0;i<pointResolution;i++) {
+          const x = Math.cos(i * 2* Math.PI / pointResolution)*2
+          const y = Math.sin(i * 2* Math.PI / pointResolution)*2
+          pathPoints.push(new THREE.Vector3(x, 0, y));
+        }
+        const pathGeo = new Line3DMesh(pathPoints, '#0000FF');
+        const pathMesh = pathGeo.getMesh();
+
+        const SetV3 = (joltV3, threeV3) => threeV3.set(joltV3.GetX(), joltV3.GetY(), joltV3.GetZ());
+        
+        const path = new Jolt.PathConstraintPathJS();
+        path.GetPathMaxFraction = () => pointResolution;
+        const tmp = new THREE.Vector3();
+        const tmp2 = new THREE.Vector3();
+        path.GetClosestPoint = (vecPtr) => {
+          const jVec3 = Jolt.wrapPointer(vecPtr, Jolt.Vec3);
+          SetV3(jVec3, tmp2);
+          const body2Loc = tmp2;
+          let closest = 31;
+          let maxLen = Number.POSITIVE_INFINITY;
+          pathPoints.forEach((p,i) => {
+            tmp.subVectors(p, body2Loc);
+            const len = tmp.length();
+            if(len < maxLen) {
+              closest = i;
+              maxLen = len;
+            }
+          });
+          return closest;
+        }
+        const normal = new THREE.Vector3(0,1,0);
+        path.GetPointOnPath = (inFraction, outPathPositionPtr, outPathTangentPtr, outPathNormalPtr, outPathBinormalPtr) => {
+          const outPathPosition = Jolt.wrapPointer(outPathPositionPtr, Jolt.Vec3);
+          const outPathTangent = Jolt.wrapPointer(outPathTangentPtr, Jolt.Vec3);
+          const outPathNormal = Jolt.wrapPointer(outPathNormalPtr, Jolt.Vec3);
+          const outPathBinormal = Jolt.wrapPointer(outPathBinormalPtr, Jolt.Vec3);
+
+          const pointAIdx = Math.floor(inFraction);
+          const pointBIdx = Math.ceil(inFraction+0.0001) % pointResolution;
+          const percent = inFraction - pointAIdx;
+
+          const pointA = pathPoints[pointAIdx];
+          const pointB = pathPoints[pointBIdx];
+          const pos = tmp.lerpVectors(pointA, pointB, percent );
+
+          outPathNormal.Set(normal.x, normal.y, normal.z);
+          outPathPosition.Set(pos.x, pos.y, pos.z);
+
+          const tan = tmp.subVectors(pointB, pointA).normalize();
+          outPathTangent.Set(tan.x, tan.y, tan.z);
+
+          const binormal = tmp.crossVectors(tan, normal).normalize();
+          outPathBinormal.Set(binormal.x, binormal.y, binormal.z);
+        }
+        Jolt.castObject(path, Jolt.PathConstraintPath).SetIsLooping(true);
+
+        const _jPosition = new Jolt.Vec3();
+        const _jTangent = new Jolt.Vec3();
+        const _jNormal = new Jolt.Vec3();
+        const _jBinormal = new Jolt.Vec3();
+
+        const positionMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
+        const positionGeo = new THREE.SphereGeometry(0.25, 32, 32);
+        function renderPathData(parent, constraint) {
+          parent.add(pathMesh.clone());
+          const pos = new THREE.Mesh(positionGeo, positionMaterial);
+          parent.add(pos);
+          const tanLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF0000');
+          pos.add(tanLine.getMesh());
+          const normLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#00FF00');
+          pos.add(normLine.getMesh());
+          const binLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF00FF');
+          pos.add(binLine.getMesh());
+
+          updates.push(() => {
+            path.GetPointOnPath(constraint.GetPathFraction(),
+              Jolt.getPointer(_jPosition),Jolt.getPointer(_jTangent),Jolt.getPointer(_jNormal),Jolt.getPointer(_jBinormal));
+            SetV3(_jPosition,pos.position);
+            SetV3(_jTangent,tanLine._points[1]);tanLine.update();
+            SetV3(_jNormal,normLine._points[1]);normLine.update();
+            SetV3(_jBinormal,binLine._points[1]);binLine.update();
+          })
+        }
+
+        let offsetX = -8;
+        let offsetZ = 0;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ff0000');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_Free
+
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+        offsetX = 0;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#00ff00');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundTangent
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+        offsetX = 8;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#0000ff');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundNormal
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+
+        offsetX = -8;
+        offsetZ = 8;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ff00ff');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundBinormal
+
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+        offsetX = 0;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ffff00');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainToPath
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+        offsetX = 8;
+        {
+          position.Set(0 + offsetX, 5, 0 + offsetZ);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+          const threeBox = dynamicObjects[dynamicObjects.length - 1]
+          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#00ffff');
+          
+          const pathConstraintSettings = new Jolt.PathConstraintSettings();
+          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_FullyConstrained
+          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+          pathConstraint.SetPath(path, 0);
+
+          physicsSystem.AddConstraint(pathConstraint);
+          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+          pathConstraint.SetTargetVelocity(2);
+          renderPathData(threeBox, pathConstraint);
+        }
+
+			});
+
+		</script>
+	</body>
+</html>

--- a/Examples/constraint_path.html
+++ b/Examples/constraint_path.html
@@ -1,268 +1,270 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>JoltPhysics.js demo</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link rel="stylesheet" type="text/css" href="style.css">
-	</head>
-	<body>
-		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js 2d path constraint demo<br/>
-			This demo shows the various constraint settings on Path RotationConstraintType<br />
-      <div style="font-weight: bold;background: rgba(0.2,0.2,0.2,0.2);display:inline-block;padding:10px">
-      <span style="color:red">Red: Free Constraint</span><br />
-      <span style="color:green">Green: Path-Tangent Constraint</span><br />
-      <span style="color:blue">Blue: Path-Normal Constraint</span><br />
-      <span style="color:magenta">Magenta: Path-Binormal Constraint</span><br />
-      <span style="color:yellow">Yellow: Path-Space Constraint</span><br />
-      <span style="color:cyan">Cyan: Fully Constrained to Body1</span></div>
-    </div>
+<head>
+	<title>JoltPhysics.js demo</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+	<div id="container">Loading...</div>
+	<div id="info">
+		JoltPhysics.js 2d path constraint demo<br />
+		This demo shows the various constraint settings on Path RotationConstraintType<br />
+		<div style="font-weight: bold;background: rgba(0.2,0.2,0.2,0.2);display:inline-block;padding:10px">
+			<span style="color:red">Red: Free Constraint</span><br />
+			<span style="color:green">Green: Path-Tangent Constraint</span><br />
+			<span style="color:blue">Blue: Path-Normal Constraint</span><br />
+			<span style="color:magenta">Magenta: Path-Binormal Constraint</span><br />
+			<span style="color:yellow">Yellow: Path-Space Constraint</span><br />
+			<span style="color:cyan">Cyan: Fully Constrained to Body1</span>
+		</div>
+	</div>
 
-		<script src="js/three/three.min.js"></script>
-		<script src="js/three/OrbitControls.js"></script>
-		<script src="js/three/WebGL.js"></script>
-		<script src="js/three/stats.min.js"></script>
-		<script src="js/example.js"></script>
+	<script src="js/three/three.min.js"></script>
+	<script src="js/three/OrbitControls.js"></script>
+	<script src="js/three/WebGL.js"></script>
+	<script src="js/three/stats.min.js"></script>
+	<script src="js/example.js"></script>
 
-		<script type="module">
-			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
-			import initJolt from './js/jolt-physics.wasm-compat.js';
+	<script type="module">
+		// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+		import initJolt from './js/jolt-physics.wasm-compat.js';
 
-      class Line3DMesh {
-        constructor(points, color) {
-          this._points = points;
-          const material = new THREE.LineBasicMaterial({ color });
-          const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints( points );
-          this._line = new THREE.Line( geometry, material ); 
-        }
+		class Line3DMesh {
+			constructor(points, color) {
+				this._points = points;
+				const material = new THREE.LineBasicMaterial({ color });
+				const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints(points);
+				this._line = new THREE.Line(geometry, material);
+			}
 
-        update() {
-          this._geometry.setFromPoints(this._points);
-        }
+			update() {
+				this._geometry.setFromPoints(this._points);
+			}
 
-        getMesh() {
-          return this._line;
-        }
-      }
+			getMesh() {
+				return this._line;
+			}
+		}
 
-      initJolt().then(function (Jolt) {
+		initJolt().then(function (Jolt) {
 
-				// Initialize this example
-        const updates = [];
-				initExample(Jolt, () => {
-          updates.forEach(func => func());
-        });
-
-				// Create a basic floor
-				createFloor();
-
-        const rotation = new Jolt.Quat.prototype.sIdentity();
-        const position = new Jolt.Vec3();
-        const size = new Jolt.Vec3(0.5,0.1,0.5);
-
-        const pathPoints = [];
-        const pointResolution = 100;
-        for(let i=0;i<pointResolution;i++) {
-          const x = Math.cos(i * 2* Math.PI / pointResolution)*2
-          const y = Math.sin(i * 2* Math.PI / pointResolution)*2
-          pathPoints.push(new THREE.Vector3(x, 0, y));
-        }
-        const pathGeo = new Line3DMesh(pathPoints, '#0000FF');
-        const pathMesh = pathGeo.getMesh();
-
-        const SetV3 = (joltV3, threeV3) => threeV3.set(joltV3.GetX(), joltV3.GetY(), joltV3.GetZ());
-        
-        const path = new Jolt.PathConstraintPathJS();
-        path.GetPathMaxFraction = () => pointResolution;
-        const tmp = new THREE.Vector3();
-        const tmp2 = new THREE.Vector3();
-        path.GetClosestPoint = (vecPtr) => {
-          const jVec3 = Jolt.wrapPointer(vecPtr, Jolt.Vec3);
-          SetV3(jVec3, tmp2);
-          const body2Loc = tmp2;
-          let closest = 31;
-          let maxLen = Number.POSITIVE_INFINITY;
-          pathPoints.forEach((p,i) => {
-            tmp.subVectors(p, body2Loc);
-            const len = tmp.length();
-            if(len < maxLen) {
-              closest = i;
-              maxLen = len;
-            }
-          });
-          return closest;
-        }
-        const normal = new THREE.Vector3(0,1,0);
-        path.GetPointOnPath = (inFraction, outPathPositionPtr, outPathTangentPtr, outPathNormalPtr, outPathBinormalPtr) => {
-          const outPathPosition = Jolt.wrapPointer(outPathPositionPtr, Jolt.Vec3);
-          const outPathTangent = Jolt.wrapPointer(outPathTangentPtr, Jolt.Vec3);
-          const outPathNormal = Jolt.wrapPointer(outPathNormalPtr, Jolt.Vec3);
-          const outPathBinormal = Jolt.wrapPointer(outPathBinormalPtr, Jolt.Vec3);
-
-          const pointAIdx = Math.floor(inFraction);
-          const pointBIdx = Math.ceil(inFraction+0.0001) % pointResolution;
-          const percent = inFraction - pointAIdx;
-
-          const pointA = pathPoints[pointAIdx];
-          const pointB = pathPoints[pointBIdx];
-          const pos = tmp.lerpVectors(pointA, pointB, percent );
-
-          outPathNormal.Set(normal.x, normal.y, normal.z);
-          outPathPosition.Set(pos.x, pos.y, pos.z);
-
-          const tan = tmp.subVectors(pointB, pointA).normalize();
-          outPathTangent.Set(tan.x, tan.y, tan.z);
-
-          const binormal = tmp.crossVectors(tan, normal).normalize();
-          outPathBinormal.Set(binormal.x, binormal.y, binormal.z);
-        }
-        Jolt.castObject(path, Jolt.PathConstraintPath).SetIsLooping(true);
-
-        const _jPosition = new Jolt.Vec3();
-        const _jTangent = new Jolt.Vec3();
-        const _jNormal = new Jolt.Vec3();
-        const _jBinormal = new Jolt.Vec3();
-
-        const positionMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
-        const positionGeo = new THREE.SphereGeometry(0.25, 32, 32);
-        function renderPathData(parent, constraint) {
-          parent.add(pathMesh.clone());
-          const pos = new THREE.Mesh(positionGeo, positionMaterial);
-          parent.add(pos);
-          const tanLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF0000');
-          pos.add(tanLine.getMesh());
-          const normLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#00FF00');
-          pos.add(normLine.getMesh());
-          const binLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF00FF');
-          pos.add(binLine.getMesh());
-
-          updates.push(() => {
-            path.GetPointOnPath(constraint.GetPathFraction(),
-              Jolt.getPointer(_jPosition),Jolt.getPointer(_jTangent),Jolt.getPointer(_jNormal),Jolt.getPointer(_jBinormal));
-            SetV3(_jPosition,pos.position);
-            SetV3(_jTangent,tanLine._points[1]);tanLine.update();
-            SetV3(_jNormal,normLine._points[1]);normLine.update();
-            SetV3(_jBinormal,binLine._points[1]);binLine.update();
-          })
-        }
-
-        let offsetX = -8;
-        let offsetZ = 0;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ff0000');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_Free
-
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-        offsetX = 0;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#00ff00');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundTangent
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-        offsetX = 8;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#0000ff');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundNormal
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-
-        offsetX = -8;
-        offsetZ = 8;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ff00ff');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundBinormal
-
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-        offsetX = 0;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#ffff00');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainToPath
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-        offsetX = 8;
-        {
-          position.Set(0 + offsetX, 5, 0 + offsetZ);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
-          const threeBox = dynamicObjects[dynamicObjects.length - 1]
-          position.Set(2.5 + offsetX, 5, 0 + offsetZ);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING,'#00ffff');
-          
-          const pathConstraintSettings = new Jolt.PathConstraintSettings();
-          pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_FullyConstrained
-          const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
-          pathConstraint.SetPath(path, 0);
-
-          physicsSystem.AddConstraint(pathConstraint);
-          pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
-          pathConstraint.SetTargetVelocity(2);
-          renderPathData(threeBox, pathConstraint);
-        }
-
+			// Initialize this example
+			const updates = [];
+			initExample(Jolt, () => {
+				updates.forEach(func => func());
 			});
 
-		</script>
-	</body>
+			// Create a basic floor
+			createFloor();
+
+			const rotation = new Jolt.Quat.prototype.sIdentity();
+			const position = new Jolt.Vec3();
+			const size = new Jolt.Vec3(0.5, 0.1, 0.5);
+
+			const pathPoints = [];
+			const pointResolution = 100;
+			for (let i = 0; i < pointResolution; i++) {
+				const x = Math.cos(i * 2 * Math.PI / pointResolution) * 2
+				const y = Math.sin(i * 2 * Math.PI / pointResolution) * 2
+				pathPoints.push(new THREE.Vector3(x, 0, y));
+			}
+			const pathGeo = new Line3DMesh(pathPoints, '#0000FF');
+			const pathMesh = pathGeo.getMesh();
+
+			const SetV3 = (joltV3, threeV3) => threeV3.set(joltV3.GetX(), joltV3.GetY(), joltV3.GetZ());
+
+			const path = new Jolt.PathConstraintPathJS();
+			path.GetPathMaxFraction = () => pointResolution;
+			const tmp = new THREE.Vector3();
+			const tmp2 = new THREE.Vector3();
+			path.GetClosestPoint = (vecPtr) => {
+				const jVec3 = Jolt.wrapPointer(vecPtr, Jolt.Vec3);
+				SetV3(jVec3, tmp2);
+				const body2Loc = tmp2;
+				let closest = 31;
+				let maxLen = Number.POSITIVE_INFINITY;
+				pathPoints.forEach((p, i) => {
+					tmp.subVectors(p, body2Loc);
+					const len = tmp.length();
+					if (len < maxLen) {
+						closest = i;
+						maxLen = len;
+					}
+				});
+				return closest;
+			}
+			const normal = new THREE.Vector3(0, 1, 0);
+			path.GetPointOnPath = (inFraction, outPathPositionPtr, outPathTangentPtr, outPathNormalPtr, outPathBinormalPtr) => {
+				const outPathPosition = Jolt.wrapPointer(outPathPositionPtr, Jolt.Vec3);
+				const outPathTangent = Jolt.wrapPointer(outPathTangentPtr, Jolt.Vec3);
+				const outPathNormal = Jolt.wrapPointer(outPathNormalPtr, Jolt.Vec3);
+				const outPathBinormal = Jolt.wrapPointer(outPathBinormalPtr, Jolt.Vec3);
+
+				const pointAIdx = Math.floor(inFraction);
+				const pointBIdx = Math.ceil(inFraction + 0.0001) % pointResolution;
+				const percent = inFraction - pointAIdx;
+
+				const pointA = pathPoints[pointAIdx];
+				const pointB = pathPoints[pointBIdx];
+				const pos = tmp.lerpVectors(pointA, pointB, percent);
+
+				outPathNormal.Set(normal.x, normal.y, normal.z);
+				outPathPosition.Set(pos.x, pos.y, pos.z);
+
+				const tan = tmp.subVectors(pointB, pointA).normalize();
+				outPathTangent.Set(tan.x, tan.y, tan.z);
+
+				const binormal = tmp.crossVectors(tan, normal).normalize();
+				outPathBinormal.Set(binormal.x, binormal.y, binormal.z);
+			}
+			Jolt.castObject(path, Jolt.PathConstraintPath).SetIsLooping(true);
+
+			const _jPosition = new Jolt.Vec3();
+			const _jTangent = new Jolt.Vec3();
+			const _jNormal = new Jolt.Vec3();
+			const _jBinormal = new Jolt.Vec3();
+
+			const positionMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
+			const positionGeo = new THREE.SphereGeometry(0.25, 32, 32);
+			function renderPathData(parent, constraint) {
+				parent.add(pathMesh.clone());
+				const pos = new THREE.Mesh(positionGeo, positionMaterial);
+				parent.add(pos);
+				const tanLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF0000');
+				pos.add(tanLine.getMesh());
+				const normLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#00FF00');
+				pos.add(normLine.getMesh());
+				const binLine = new Line3DMesh([new THREE.Vector3(), new THREE.Vector3()], '#FF00FF');
+				pos.add(binLine.getMesh());
+
+				updates.push(() => {
+					path.GetPointOnPath(constraint.GetPathFraction(),
+						Jolt.getPointer(_jPosition), Jolt.getPointer(_jTangent), Jolt.getPointer(_jNormal), Jolt.getPointer(_jBinormal));
+					SetV3(_jPosition, pos.position);
+					SetV3(_jTangent, tanLine._points[1]); tanLine.update();
+					SetV3(_jNormal, normLine._points[1]); normLine.update();
+					SetV3(_jBinormal, binLine._points[1]); binLine.update();
+				})
+			}
+
+			let offsetX = -8;
+			let offsetZ = 0;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#ff0000');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_Free
+
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+			offsetX = 0;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#00ff00');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundTangent
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+			offsetX = 8;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#0000ff');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundNormal
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+
+			offsetX = -8;
+			offsetZ = 8;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#ff00ff');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainAroundBinormal
+
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+			offsetX = 0;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#ffff00');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_ConstrainToPath
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+			offsetX = 8;
+			{
+				position.Set(0 + offsetX, 5, 0 + offsetZ);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Static, LAYER_NON_MOVING);
+				const threeBox = dynamicObjects[dynamicObjects.length - 1]
+				position.Set(2.5 + offsetX, 5, 0 + offsetZ);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING, '#00ffff');
+
+				const pathConstraintSettings = new Jolt.PathConstraintSettings();
+				pathConstraintSettings.mRotationConstraintType = Jolt.EPathRotationConstraintType_FullyConstrained
+				const pathConstraint = Jolt.castObject(pathConstraintSettings.Create(box1, box2), Jolt.PathConstraint);
+				pathConstraint.SetPath(path, 0);
+
+				physicsSystem.AddConstraint(pathConstraint);
+				pathConstraint.SetPositionMotorState(Jolt.EMotorState_Velocity);
+				pathConstraint.SetTargetVelocity(2);
+				renderPathData(threeBox, pathConstraint);
+			}
+
+		});
+
+	</script>
+</body>
 </html>

--- a/Examples/constraint_pulley.html
+++ b/Examples/constraint_pulley.html
@@ -1,240 +1,241 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>JoltPhysics.js demo</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link rel="stylesheet" type="text/css" href="style.css">
-	</head>
-	<body>
-		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js 2d pulley demo<br/>
-			This demo shows various cases of Pulley Constraints<br />
-      Pulleys in the back have different ratios, allowing the right side to pull up more or less rope.<br />
-      Pulleys in the front demonstrate varying weights, carrying capacity, and attachment points of connections.
-    </div>
+<head>
+	<title>JoltPhysics.js demo</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+	<div id="container">Loading...</div>
+	<div id="info">
+		JoltPhysics.js 2d pulley demo<br />
+		This demo shows various cases of Pulley Constraints<br />
+		Pulleys in the back have different ratios, allowing the right side to pull up more or less rope.<br />
+		Pulleys in the front demonstrate varying weights, carrying capacity, and attachment points of connections.
+	</div>
 
-		<script src="js/three/three.min.js"></script>
-		<script src="js/three/OrbitControls.js"></script>
-		<script src="js/three/WebGL.js"></script>
-		<script src="js/three/stats.min.js"></script>
-		<script src="js/example.js"></script>
+	<script src="js/three/three.min.js"></script>
+	<script src="js/three/OrbitControls.js"></script>
+	<script src="js/three/WebGL.js"></script>
+	<script src="js/three/stats.min.js"></script>
+	<script src="js/example.js"></script>
 
-		<script type="module">
-			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
-			import initJolt from './js/jolt-physics.wasm-compat.js';
-
-
-      class Line3DMesh {
-
-        constructor(point1, point2, color) {
-          this.point1 = point1;
-          this.point2 = point2;
-          const points = this._points = [point1, point2];
-          const material = new THREE.LineBasicMaterial({ color });
-          const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints( points );
-          this._line = new THREE.Line( geometry, material ); 
-        }
-
-        update() {
-          this._geometry.setFromPoints(this._points);
-        }
-
-        getMesh() {
-          return this._line;
-        }
-      }
+	<script type="module">
+		// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+		import initJolt from './js/jolt-physics.wasm-compat.js';
 
 
-			initJolt().then(function (Jolt) {
+		class Line3DMesh {
 
-        const lineUpdates = [];
-				// Initialize this example
-				initExample(Jolt, () => {
-          lineUpdates.forEach(func => func());
-        });
+			constructor(point1, point2, color) {
+				this.point1 = point1;
+				this.point2 = point2;
+				const points = this._points = [point1, point2];
+				const material = new THREE.LineBasicMaterial({ color });
+				const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints(points);
+				this._line = new THREE.Line(geometry, material);
+			}
 
-        const fixedPointMaterial = new THREE.MeshPhongMaterial({ color: '#ffff00' });
-        const bodyPointMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
-        const fixedPointGeometry = new THREE.SphereGeometry(0.25, 32, 32);
-        function createPulleyGraphics(threeBox1, threeBox2, attachOffset1, attachOffset2, fixed1, fixed2, constraintSettings) {
-          const fixedPoint1 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
-          const fixedPoint2 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
-          const bodyPoint1 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
-          const bodyPoint2 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
-          scene.add(fixedPoint1);
-          scene.add(fixedPoint2);
-          threeBox1.add(bodyPoint1);
-          threeBox2.add(bodyPoint2);
-          fixedPoint1.position.copy(fixed1);
-          fixedPoint2.position.copy(fixed2);
-          bodyPoint1.position.copy(attachOffset1);
-          bodyPoint2.position.copy(attachOffset2);
+			update() {
+				this._geometry.setFromPoints(this._points);
+			}
 
-          constraintSettings.mFixedPoint1.Set(fixed1.x, fixed1.y, fixed1.z);
-          constraintSettings.mFixedPoint2.Set(fixed2.x, fixed2.y, fixed2.z);
-          constraintSettings.mSpace = Jolt.EConstraintSpace_LocalToBodyCOM;
-          constraintSettings.mBodyPoint1.Set(attachOffset1.x, attachOffset1.y, attachOffset1.z);
-          constraintSettings.mBodyPoint2.Set(attachOffset2.x, attachOffset2.y, attachOffset2.z);
+			getMesh() {
+				return this._line;
+			}
+		}
 
-          const line1 = new Line3DMesh(new THREE.Vector3(), fixedPoint1.position, '#FF0000');
-          const line2 = new Line3DMesh(new THREE.Vector3(), fixedPoint2.position, '#0000FF');
-          const line3 = new Line3DMesh(fixedPoint1.position, fixedPoint2.position, '#00FF00');
-          scene.add(line1.getMesh());
-          scene.add(line2.getMesh());
-          scene.add(line3.getMesh());
 
-          lineUpdates.push(
-            () => {
-              bodyPoint1.getWorldPosition(line1.point1);
-              line1.update();
-            },
-            () => {
-              bodyPoint2.getWorldPosition(line2.point1);
-              line2.update();
-            }
-          );
-        }
+		initJolt().then(function (Jolt) {
 
-				// Create a basic floor
-				createFloor();
-
-        const rotation = new Jolt.Quat.prototype.sIdentity();
-        const position = new Jolt.Vec3();
-        const size = new Jolt.Vec3(0.5,0.1,0.5);
-
-        
-        let xOffset = -10;
-
-        {
-          position.Set(xOffset - 1, 4, 0);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/111);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 4, 0);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/112);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          position.Set(xOffset - 1, 4.6, 0);
-          const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          weight.GetMotionProperties().SetInverseMass(1/111);
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-
-        xOffset = -5;
-        {
-          position.Set(xOffset - 0.6, 4, 0);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/111);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 0.6, 4, 0);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/112);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-        xOffset = 0;
-        {
-          position.Set(xOffset - 1, 4, 0);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 4, 0);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          position.Set(xOffset - 1.1, 4.6, .1);
-          const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-        xOffset = 5;
-        {
-          position.Set(xOffset - 1, 4, 1);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 4, -1);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          position.Set(xOffset - 1.1, 4.6, .1);
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(-0.5,0.1,0), new THREE.Vector3(0.5,0.1,0.5), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-        xOffset = -2;
-        let zOffset = -8;
-        {
-          position.Set(xOffset - 1, 6, 0 + zOffset);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/2);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 6, 0 + zOffset);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box2.GetMotionProperties().SetInverseMass(1/4);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          pulley1.mRatio = 1;
-          createPulleyGraphics(threeBox1, threeBox2, 
-                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
-                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-        xOffset = 4;
-        {
-          position.Set(xOffset - 1, 6, 0 + zOffset);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/2);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 6, 0 + zOffset);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box2.GetMotionProperties().SetInverseMass(1/4);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          pulley1.mRatio = 0.6;
-          createPulleyGraphics(threeBox1, threeBox2, 
-                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
-                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
-        xOffset = 10;
-        {
-          position.Set(xOffset - 1, 6, 0 + zOffset);
-          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box1.GetMotionProperties().SetInverseMass(1/2);
-          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
-          position.Set(xOffset + 1, 6, 0 + zOffset);
-          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-          box2.GetMotionProperties().SetInverseMass(1/4);
-          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
-
-          const pulley1 = new Jolt.PulleyConstraintSettings();
-          pulley1.mRatio = 0.2;
-          createPulleyGraphics(threeBox1, threeBox2, 
-                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
-                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
-
-          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
-        }
+			const lineUpdates = [];
+			// Initialize this example
+			initExample(Jolt, () => {
+				lineUpdates.forEach(func => func());
 			});
 
-		</script>
-	</body>
+			const fixedPointMaterial = new THREE.MeshPhongMaterial({ color: '#ffff00' });
+			const bodyPointMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
+			const fixedPointGeometry = new THREE.SphereGeometry(0.25, 32, 32);
+			function createPulleyGraphics(threeBox1, threeBox2, attachOffset1, attachOffset2, fixed1, fixed2, constraintSettings) {
+				const fixedPoint1 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
+				const fixedPoint2 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
+				const bodyPoint1 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
+				const bodyPoint2 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
+				scene.add(fixedPoint1);
+				scene.add(fixedPoint2);
+				threeBox1.add(bodyPoint1);
+				threeBox2.add(bodyPoint2);
+				fixedPoint1.position.copy(fixed1);
+				fixedPoint2.position.copy(fixed2);
+				bodyPoint1.position.copy(attachOffset1);
+				bodyPoint2.position.copy(attachOffset2);
+
+				constraintSettings.mFixedPoint1.Set(fixed1.x, fixed1.y, fixed1.z);
+				constraintSettings.mFixedPoint2.Set(fixed2.x, fixed2.y, fixed2.z);
+				constraintSettings.mSpace = Jolt.EConstraintSpace_LocalToBodyCOM;
+				constraintSettings.mBodyPoint1.Set(attachOffset1.x, attachOffset1.y, attachOffset1.z);
+				constraintSettings.mBodyPoint2.Set(attachOffset2.x, attachOffset2.y, attachOffset2.z);
+
+				const line1 = new Line3DMesh(new THREE.Vector3(), fixedPoint1.position, '#FF0000');
+				const line2 = new Line3DMesh(new THREE.Vector3(), fixedPoint2.position, '#0000FF');
+				const line3 = new Line3DMesh(fixedPoint1.position, fixedPoint2.position, '#00FF00');
+				scene.add(line1.getMesh());
+				scene.add(line2.getMesh());
+				scene.add(line3.getMesh());
+
+				lineUpdates.push(
+					() => {
+						bodyPoint1.getWorldPosition(line1.point1);
+						line1.update();
+					},
+					() => {
+						bodyPoint2.getWorldPosition(line2.point1);
+						line2.update();
+					}
+				);
+			}
+
+			// Create a basic floor
+			createFloor();
+
+			const rotation = new Jolt.Quat.prototype.sIdentity();
+			const position = new Jolt.Vec3();
+			const size = new Jolt.Vec3(0.5, 0.1, 0.5);
+
+
+			let xOffset = -10;
+
+			{
+				position.Set(xOffset - 1, 4, 0);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 111);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 4, 0);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 112);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				position.Set(xOffset - 1, 4.6, 0);
+				const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				weight.GetMotionProperties().SetInverseMass(1 / 111);
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(xOffset - 1, 9, 0), new THREE.Vector3(xOffset + 1, 9, 0), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+
+			xOffset = -5;
+			{
+				position.Set(xOffset - 0.6, 4, 0);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 111);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 0.6, 4, 0);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 112);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(xOffset - 1, 9, 0), new THREE.Vector3(xOffset + 1, 9, 0), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+			xOffset = 0;
+			{
+				position.Set(xOffset - 1, 4, 0);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 4, 0);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				position.Set(xOffset - 1.1, 4.6, .1);
+				const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(xOffset - 1, 9, 0), new THREE.Vector3(xOffset + 1, 9, 0), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+			xOffset = 5;
+			{
+				position.Set(xOffset - 1, 4, 1);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 4, -1);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				position.Set(xOffset - 1.1, 4.6, .1);
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(-0.5, 0.1, 0), new THREE.Vector3(0.5, 0.1, 0.5), new THREE.Vector3(xOffset - 1, 9, 0), new THREE.Vector3(xOffset + 1, 9, 0), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+			xOffset = -2;
+			let zOffset = -8;
+			{
+				position.Set(xOffset - 1, 6, 0 + zOffset);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 2);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 6, 0 + zOffset);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box2.GetMotionProperties().SetInverseMass(1 / 4);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				pulley1.mRatio = 1;
+				createPulleyGraphics(threeBox1, threeBox2,
+					new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0),
+					new THREE.Vector3(xOffset - 1, 14, 0 + zOffset), new THREE.Vector3(xOffset + 1, 14, 0 + zOffset), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+			xOffset = 4;
+			{
+				position.Set(xOffset - 1, 6, 0 + zOffset);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 2);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 6, 0 + zOffset);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box2.GetMotionProperties().SetInverseMass(1 / 4);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				pulley1.mRatio = 0.6;
+				createPulleyGraphics(threeBox1, threeBox2,
+					new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0),
+					new THREE.Vector3(xOffset - 1, 14, 0 + zOffset), new THREE.Vector3(xOffset + 1, 14, 0 + zOffset), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+			xOffset = 10;
+			{
+				position.Set(xOffset - 1, 6, 0 + zOffset);
+				const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box1.GetMotionProperties().SetInverseMass(1 / 2);
+				const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+				position.Set(xOffset + 1, 6, 0 + zOffset);
+				const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				box2.GetMotionProperties().SetInverseMass(1 / 4);
+				const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+				const pulley1 = new Jolt.PulleyConstraintSettings();
+				pulley1.mRatio = 0.2;
+				createPulleyGraphics(threeBox1, threeBox2,
+					new THREE.Vector3(0, 0.1, 0), new THREE.Vector3(0, 0.1, 0),
+					new THREE.Vector3(xOffset - 1, 14, 0 + zOffset), new THREE.Vector3(xOffset + 1, 14, 0 + zOffset), pulley1);
+
+				physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+			}
+		});
+
+	</script>
+</body>
 </html>

--- a/Examples/constraint_pulley.html
+++ b/Examples/constraint_pulley.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js 2d pulley demo<br/>
+			This demo shows various cases of Pulley Constraints<br />
+      Pulleys in the back have different ratios, allowing the right side to pull up more or less rope.<br />
+      Pulleys in the front demonstrate varying weights, carrying capacity, and attachment points of connections.
+    </div>
+
+		<script src="js/three/three.min.js"></script>
+		<script src="js/three/OrbitControls.js"></script>
+		<script src="js/three/WebGL.js"></script>
+		<script src="js/three/stats.min.js"></script>
+		<script src="js/example.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from './js/jolt-physics.wasm-compat.js';
+
+
+      class Line3DMesh {
+
+        constructor(point1, point2, color) {
+          this.point1 = point1;
+          this.point2 = point2;
+          const points = this._points = [point1, point2];
+          const material = new THREE.LineBasicMaterial({ color });
+          const geometry = this._geometry = new THREE.BufferGeometry().setFromPoints( points );
+          this._line = new THREE.Line( geometry, material ); 
+        }
+
+        update() {
+          this._geometry.setFromPoints(this._points);
+        }
+
+        getMesh() {
+          return this._line;
+        }
+      }
+
+
+			initJolt().then(function (Jolt) {
+
+        const lineUpdates = [];
+				// Initialize this example
+				initExample(Jolt, () => {
+          lineUpdates.forEach(func => func());
+        });
+
+        const fixedPointMaterial = new THREE.MeshPhongMaterial({ color: '#ffff00' });
+        const bodyPointMaterial = new THREE.MeshPhongMaterial({ color: '#00ff00' });
+        const fixedPointGeometry = new THREE.SphereGeometry(0.25, 32, 32);
+        function createPulleyGraphics(threeBox1, threeBox2, attachOffset1, attachOffset2, fixed1, fixed2, constraintSettings) {
+          const fixedPoint1 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
+          const fixedPoint2 = new THREE.Mesh(fixedPointGeometry, fixedPointMaterial);
+          const bodyPoint1 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
+          const bodyPoint2 = new THREE.Mesh(fixedPointGeometry, bodyPointMaterial);
+          scene.add(fixedPoint1);
+          scene.add(fixedPoint2);
+          threeBox1.add(bodyPoint1);
+          threeBox2.add(bodyPoint2);
+          fixedPoint1.position.copy(fixed1);
+          fixedPoint2.position.copy(fixed2);
+          bodyPoint1.position.copy(attachOffset1);
+          bodyPoint2.position.copy(attachOffset2);
+
+          constraintSettings.mFixedPoint1.Set(fixed1.x, fixed1.y, fixed1.z);
+          constraintSettings.mFixedPoint2.Set(fixed2.x, fixed2.y, fixed2.z);
+          constraintSettings.mSpace = Jolt.EConstraintSpace_LocalToBodyCOM;
+          constraintSettings.mBodyPoint1.Set(attachOffset1.x, attachOffset1.y, attachOffset1.z);
+          constraintSettings.mBodyPoint2.Set(attachOffset2.x, attachOffset2.y, attachOffset2.z);
+
+          const line1 = new Line3DMesh(new THREE.Vector3(), fixedPoint1.position, '#FF0000');
+          const line2 = new Line3DMesh(new THREE.Vector3(), fixedPoint2.position, '#0000FF');
+          const line3 = new Line3DMesh(fixedPoint1.position, fixedPoint2.position, '#00FF00');
+          scene.add(line1.getMesh());
+          scene.add(line2.getMesh());
+          scene.add(line3.getMesh());
+
+          lineUpdates.push(
+            () => {
+              bodyPoint1.getWorldPosition(line1.point1);
+              line1.update();
+            },
+            () => {
+              bodyPoint2.getWorldPosition(line2.point1);
+              line2.update();
+            }
+          );
+        }
+
+				// Create a basic floor
+				createFloor();
+
+        const rotation = new Jolt.Quat.prototype.sIdentity();
+        const position = new Jolt.Vec3();
+        const size = new Jolt.Vec3(0.5,0.1,0.5);
+
+        
+        let xOffset = -10;
+
+        {
+          position.Set(xOffset - 1, 4, 0);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/111);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 4, 0);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/112);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          position.Set(xOffset - 1, 4.6, 0);
+          const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          weight.GetMotionProperties().SetInverseMass(1/111);
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+
+        xOffset = -5;
+        {
+          position.Set(xOffset - 0.6, 4, 0);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/111);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 0.6, 4, 0);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/112);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+        xOffset = 0;
+        {
+          position.Set(xOffset - 1, 4, 0);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 4, 0);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          position.Set(xOffset - 1.1, 4.6, .1);
+          const weight = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+        xOffset = 5;
+        {
+          position.Set(xOffset - 1, 4, 1);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 4, -1);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          position.Set(xOffset - 1.1, 4.6, .1);
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          createPulleyGraphics(threeBox1, threeBox2, new THREE.Vector3(-0.5,0.1,0), new THREE.Vector3(0.5,0.1,0.5), new THREE.Vector3(xOffset - 1,9,0), new THREE.Vector3(xOffset + 1,9,0), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+        xOffset = -2;
+        let zOffset = -8;
+        {
+          position.Set(xOffset - 1, 6, 0 + zOffset);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/2);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 6, 0 + zOffset);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box2.GetMotionProperties().SetInverseMass(1/4);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          pulley1.mRatio = 1;
+          createPulleyGraphics(threeBox1, threeBox2, 
+                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
+                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+        xOffset = 4;
+        {
+          position.Set(xOffset - 1, 6, 0 + zOffset);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/2);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 6, 0 + zOffset);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box2.GetMotionProperties().SetInverseMass(1/4);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          pulley1.mRatio = 0.6;
+          createPulleyGraphics(threeBox1, threeBox2, 
+                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
+                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+        xOffset = 10;
+        {
+          position.Set(xOffset - 1, 6, 0 + zOffset);
+          const box1 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box1.GetMotionProperties().SetInverseMass(1/2);
+          const threeBox1 = dynamicObjects[dynamicObjects.length - 1];
+          position.Set(xOffset + 1, 6, 0 + zOffset);
+          const box2 = createBox(position, rotation, size, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+          box2.GetMotionProperties().SetInverseMass(1/4);
+          const threeBox2 = dynamicObjects[dynamicObjects.length - 1];
+
+          const pulley1 = new Jolt.PulleyConstraintSettings();
+          pulley1.mRatio = 0.2;
+          createPulleyGraphics(threeBox1, threeBox2, 
+                new THREE.Vector3(0,0.1,0), new THREE.Vector3(0,0.1,0),
+                new THREE.Vector3(xOffset - 1,14,0 + zOffset), new THREE.Vector3(xOffset + 1,14,0 + zOffset), pulley1);
+
+          physicsSystem.AddConstraint(pulley1.Create(box1, box2))
+        }
+			});
+
+		</script>
+	</body>
+</html>

--- a/Examples/index.html
+++ b/Examples/index.html
@@ -17,6 +17,8 @@
 			<li><a href="rig/kinematic_rig.html">Kinematic Rig</a> - Shows the process of playing an animation with a Kinemetic ragdoll</li>
 			<li><a href="rig/powered_rig.html">Powered Rig</a> - Shows the process of playing an animation with a Dynamic ragdoll and motors</li>
 			<li><a href="constraints.html">Constraints Demo</a> - Shows supported constraint types</li>
+			<li><a href="constraint_pulley.html">Pulley Demo</a> - Shows pulley constraint capabilities</li>
+			<li><a href="constraint_path.html">Path Demo</a> - Shows various path rotation constraint types</li>
 			<li><a href="motor.html">Constraint Motor Demo</a> - Shows how to use constraint motors</li>
 			<li><a href="2d_funnel.html">2D Funnel</a> - Shows how to limit bodies in a 2D plane</li>
 			<li><a href="conveyor_belt.html">Conveyor Belt Demo</a> - Shows how to do a conveyor belt</li>

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -596,18 +596,18 @@ public:
 class PathConstraintPathEm: public PathConstraintPath
 {
 public:
-	virtual float 		GetClosestPoint(Vec3Arg inPosition) const
+	virtual float 			GetClosestPoint(Vec3Arg inPosition) const
 	{
 		return GetClosestPoint(&inPosition);
 	}
 	
-	virtual void 		GetPointOnPath(float inFraction, Vec3 &outPathPosition, Vec3 &outPathTangent, Vec3 &outPathNormal, Vec3 &outPathBinormal) const
+	virtual void 			GetPointOnPath(float inFraction, Vec3 &outPathPosition, Vec3 &outPathTangent, Vec3 &outPathNormal, Vec3 &outPathBinormal) const
 	{
 		GetPointOnPath(inFraction, &outPathPosition, &outPathTangent, &outPathNormal, &outPathBinormal);
 	}
 
-	virtual float 		GetClosestPoint(Vec3 *inPosition) const = 0;
-	virtual void 		GetPointOnPath(float inFraction, Vec3 *outPathPosition, Vec3 *outPathTangent, Vec3 *outPathNormal, Vec3 *outPathBinormal) const = 0;
+	virtual float 			GetClosestPoint(Vec3 *inPosition) const = 0;
+	virtual void 			GetPointOnPath(float inFraction, Vec3 *outPathPosition, Vec3 *outPathTangent, Vec3 *outPathNormal, Vec3 *outPathBinormal) const = 0;
 };
 
 class HeightFieldShapeConstantValues 

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -595,16 +595,19 @@ public:
 
 class PathConstraintPathEm: public PathConstraintPath
 {
-	public:
-		virtual float GetClosestPoint(Vec3Arg inPosition) const {
-			return GetClosestPoint(&inPosition);
-		}
-		virtual void GetPointOnPath(float inFraction, Vec3 &outPathPosition, Vec3 &outPathTangent, Vec3 &outPathNormal, Vec3 &outPathBinormal) const  {
-			GetPointOnPath(inFraction, &outPathPosition, &outPathTangent, &outPathNormal, &outPathBinormal);
-		}
+public:
+	virtual float 		GetClosestPoint(Vec3Arg inPosition) const
+	{
+		return GetClosestPoint(&inPosition);
+	}
+	
+	virtual void 		GetPointOnPath(float inFraction, Vec3 &outPathPosition, Vec3 &outPathTangent, Vec3 &outPathNormal, Vec3 &outPathBinormal) const
+	{
+		GetPointOnPath(inFraction, &outPathPosition, &outPathTangent, &outPathNormal, &outPathBinormal);
+	}
 
-		virtual float GetClosestPoint(Vec3 *inPosition) const = 0;
-		virtual void GetPointOnPath(float inFraction, Vec3 *outPathPosition, Vec3 *outPathTangent, Vec3 *outPathNormal, Vec3 *outPathBinormal) const = 0;
+	virtual float 		GetClosestPoint(Vec3 *inPosition) const = 0;
+	virtual void 		GetPointOnPath(float inFraction, Vec3 *outPathPosition, Vec3 *outPathTangent, Vec3 *outPathNormal, Vec3 *outPathBinormal) const = 0;
 };
 
 class HeightFieldShapeConstantValues 

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -35,6 +35,9 @@
 #include "Jolt/Physics/Constraints/DistanceConstraint.h"
 #include "Jolt/Physics/Constraints/HingeConstraint.h"
 #include "Jolt/Physics/Constraints/ConeConstraint.h"
+#include "Jolt/Physics/Constraints/PathConstraint.h"
+#include "Jolt/Physics/Constraints/PathConstraintPath.h"
+#include "Jolt/Physics/Constraints/PulleyConstraint.h"
 #include "Jolt/Physics/Constraints/SliderConstraint.h"
 #include "Jolt/Physics/Constraints/SwingTwistConstraint.h"
 #include "Jolt/Physics/Constraints/SixDOFConstraint.h"
@@ -234,6 +237,14 @@ constexpr EConstraintSubType EConstraintSubType_Vehicle = EConstraintSubType::Ve
 constexpr EConstraintSubType EConstraintSubType_RackAndPinion = EConstraintSubType::RackAndPinion;
 constexpr EConstraintSubType EConstraintSubType_Gear = EConstraintSubType::Gear;
 constexpr EConstraintSubType EConstraintSubType_Pulley = EConstraintSubType::Pulley;
+
+/// Alias for EPathRotationConstraintType to avoid clash
+constexpr EPathRotationConstraintType EPathRotationConstraintType_Free = EPathRotationConstraintType::Free; 
+constexpr EPathRotationConstraintType EPathRotationConstraintType_ConstrainAroundTangent = EPathRotationConstraintType::ConstrainAroundTangent; 
+constexpr EPathRotationConstraintType EPathRotationConstraintType_ConstrainAroundNormal = EPathRotationConstraintType::ConstrainAroundNormal; 
+constexpr EPathRotationConstraintType EPathRotationConstraintType_ConstrainAroundBinormal = EPathRotationConstraintType::ConstrainAroundBinormal; 
+constexpr EPathRotationConstraintType EPathRotationConstraintType_ConstrainToPath = EPathRotationConstraintType::ConstaintToPath;  //typo in original
+constexpr EPathRotationConstraintType EPathRotationConstraintType_FullyConstrained = EPathRotationConstraintType::FullyConstrained; 
 
 // Alias for SixDOFConstraintSettings::EAxis to avoid clashes
 using SixDOFConstraintSettings_EAxis = SixDOFConstraintSettings::EAxis;
@@ -580,6 +591,20 @@ public:
 	virtual void			OnPreStepCallback(VehicleConstraint &inVehicle, float inDeltaTime, PhysicsSystem &inPhysicsSystem) = 0;
 	virtual void			OnPostCollideCallback(VehicleConstraint &inVehicle, float inDeltaTime, PhysicsSystem &inPhysicsSystem) = 0;
 	virtual void			OnPostStepCallback(VehicleConstraint &inVehicle, float inDeltaTime, PhysicsSystem &inPhysicsSystem) = 0;
+};
+
+class PathConstraintPathEm: public PathConstraintPath
+{
+	public:
+		virtual float GetClosestPoint(Vec3Arg inPosition) const {
+			return GetClosestPoint(&inPosition);
+		}
+		virtual void GetPointOnPath(float inFraction, Vec3 &outPathPosition, Vec3 &outPathTangent, Vec3 &outPathNormal, Vec3 &outPathBinormal) const  {
+			GetPointOnPath(inFraction, &outPathPosition, &outPathTangent, &outPathNormal, &outPathBinormal);
+		}
+
+		virtual float GetClosestPoint(Vec3 *inPosition) const = 0;
+		virtual void GetPointOnPath(float inFraction, Vec3 *outPathPosition, Vec3 *outPathTangent, Vec3 *outPathNormal, Vec3 *outPathBinormal) const = 0;
 };
 
 class HeightFieldShapeConstantValues 

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -190,6 +190,15 @@ enum ESwingType {
 	"ESwingType_Pyramid",
 };
 
+enum EPathRotationConstraintType {
+	"EPathRotationConstraintType_Free",
+	"EPathRotationConstraintType_ConstrainAroundTangent",
+	"EPathRotationConstraintType_ConstrainAroundNormal",
+	"EPathRotationConstraintType_ConstrainAroundBinormal",
+	"EPathRotationConstraintType_ConstrainToPath",
+	"EPathRotationConstraintType_FullyConstrained"
+};
+
 interface Vec3MemRef {
 };
 
@@ -1235,6 +1244,74 @@ interface SixDOFConstraint {
 };
 
 SixDOFConstraint implements TwoBodyConstraint;
+
+interface PathConstraintSettings {
+	void PathConstraintSettings();
+	[Value] attribute Vec3 mPathPosition;
+	[Value] attribute Quat mPathRotation;
+	attribute float mPathFraction;
+	attribute float mMaxFrictionForce;
+	attribute EPathRotationConstraintType mRotationConstraintType;
+	[Value] attribute MotorSettings mPositionMotorSettings;
+};
+PathConstraintSettings implements TwoBodyConstraintSettings;
+
+interface PathConstraintPath {
+	boolean IsLooping();
+	void SetIsLooping(boolean inIsLooping);
+	unsigned long GetRefCount();
+	void AddRef();
+	void Release();
+};
+
+interface PathConstraintPathEm {
+};
+PathConstraintPathJS implements PathConstraintPath;
+
+[JSImplementation="PathConstraintPathEm"]
+interface PathConstraintPathJS {
+	[Const] void PathConstraintPathJS();
+	[Const] float GetPathMaxFraction();
+	[Const] float GetClosestPoint(Vec3 inPosition);
+	[Const] void GetPointOnPath(float inFraction, Vec3 outPathPosition, Vec3 outPathTangent, Vec3 outPathNormal, Vec3 outPathBinormal);
+};
+
+interface PathConstraint {
+	void SetPath([Const] PathConstraintPath inPath, float inPathFraction);
+	[Const] PathConstraintPath GetPath();
+	float GetPathFraction();
+	void SetMaxFrictionForce(float inFrictionForce);
+	float GetMaxFrictionForce();
+	[Ref] MotorSettings GetPositionMotorSettings();
+	void SetPositionMotorState(EMotorState inState);
+	EMotorState GetPositionMotorState();
+	void SetTargetVelocity(float inVelocity);
+	float GetTargetVelocity();
+	void SetTargetPathFraction(float inFraction);
+	float GetTargetPathFraction();
+};
+PathConstraint implements TwoBodyConstraint;
+
+interface PulleyConstraintSettings {
+	void PulleyConstraintSettings();
+	attribute EConstraintSpace mSpace;
+	[Value] attribute Vec3 mBodyPoint1;
+	[Value] attribute Vec3 mFixedPoint1;
+	[Value] attribute Vec3 mBodyPoint2;
+	[Value] attribute Vec3 mFixedPoint2;
+	attribute float mRatio;
+	attribute float mMinLength;
+	attribute float mMaxLength;
+};
+PulleyConstraintSettings implements TwoBodyConstraintSettings;
+
+interface PulleyConstraint {
+	void SetLength(float inMinLength, float inMaxLength);
+	float GetMinLength();
+	float GetMaxLength();
+	float GetCurrentLength();	
+};
+PulleyConstraint implements TwoBodyConstraint;
 
 interface BodyID {
 	void BodyID();

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -1247,6 +1247,8 @@ SixDOFConstraint implements TwoBodyConstraint;
 
 interface PathConstraintSettings {
 	void PathConstraintSettings();
+	
+	[Const] attribute PathConstraintPath mPath;
 	[Value] attribute Vec3 mPathPosition;
 	[Value] attribute Quat mPathRotation;
 	attribute float mPathFraction;
@@ -1254,6 +1256,7 @@ interface PathConstraintSettings {
 	attribute EPathRotationConstraintType mRotationConstraintType;
 	[Value] attribute MotorSettings mPositionMotorSettings;
 };
+
 PathConstraintSettings implements TwoBodyConstraintSettings;
 
 interface PathConstraintPath {
@@ -1266,6 +1269,7 @@ interface PathConstraintPath {
 
 interface PathConstraintPathEm {
 };
+
 PathConstraintPathJS implements PathConstraintPath;
 
 [JSImplementation="PathConstraintPathEm"]
@@ -1290,10 +1294,12 @@ interface PathConstraint {
 	void SetTargetPathFraction(float inFraction);
 	float GetTargetPathFraction();
 };
+
 PathConstraint implements TwoBodyConstraint;
 
 interface PulleyConstraintSettings {
 	void PulleyConstraintSettings();
+	
 	attribute EConstraintSpace mSpace;
 	[Value] attribute Vec3 mBodyPoint1;
 	[Value] attribute Vec3 mFixedPoint1;
@@ -1303,6 +1309,7 @@ interface PulleyConstraintSettings {
 	attribute float mMinLength;
 	attribute float mMaxLength;
 };
+
 PulleyConstraintSettings implements TwoBodyConstraintSettings;
 
 interface PulleyConstraint {
@@ -1311,6 +1318,7 @@ interface PulleyConstraint {
 	float GetMaxLength();
 	float GetCurrentLength();	
 };
+
 PulleyConstraint implements TwoBodyConstraint;
 
 interface BodyID {


### PR DESCRIPTION
The pulley constraint is straight-forward. Though I couldn't figure out a good demo of various weights on the pulley.
I was tempted to wire it to a draw-bridge and push a giant rock on one side, and might do that in my actual games.

The paths were made so I can do nice floating platforms in a jumper game.
ex: Mario64's moving platform puzzles (most Bowser levels, Rainbow Ride, Tick Tock Clock)

The Path Constraint is functional with a custom JS Path, but the demo implementation is not the ideal way to do it.
The demo currently uses a high-res sample of the path and brute force catches 'closest point' and uses that to assign the mFraction of the constraint on the path. I'd thought of using an SVG path object since that supports a mirrored 2D functionality of `pathElement.getPointAtLength(n)` and `pathElement.getTotalLength()`

The normal/binormal/tangent is still likely how you would do it in most cases.

For `GetClosestPoint`, ideally instead you would use a lookup data-structure, pre-calculated for most likely/common Body2 locations. For 2D-ish paths, you can even just make a data-texture of common locations and pre-calculated 'XY coord is closest to mPathFraction" as an instant lookup.

Possibly maintain multiple Path objects would help, so there exists a per Constraint context with a memory of 'prior mPathFraction' and jump near there to start the search. That would also solve the problem I had when I tried to do figure-8s and other complex self-crossing paths, where the mBody2 location search would jump-track when a path crossed itself, since without a memory you don't know which of the crossed paths to take. https://github.com/jrouwe/JoltPhysics/blob/master/Jolt/Physics/Constraints/PathConstraint.cpp#L122 . 