### PR TITLE
WebIDL: Occurrences of [Const,Ref] passed as Value

### DIFF
--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -1432,7 +1432,7 @@ interface CollisionGroup {
 };
 
 interface Body {
-	[Value] BodyID GetID();
+	[Const, Ref] BodyID GetID();
 	boolean IsActive();
 	boolean IsRigidBody();
 	boolean IsSoftBody();
@@ -1651,10 +1651,10 @@ interface ContactSettings {
 
 interface SubShapeIDPair {
 	void SubShapeIDPair();
-	[Value] BodyID GetBody1ID();
-	[Value] SubShapeID GetSubShapeID1();
-	[Value] BodyID GetBody2ID();
-	[Value] SubShapeID GetSubShapeID2();
+	[Const, Ref] BodyID GetBody1ID();
+	[Const, Ref] SubShapeID GetSubShapeID1();
+	[Const, Ref] BodyID GetBody2ID();
+	[Const, Ref] SubShapeID GetSubShapeID2();
 };
 
 interface ContactListener {
@@ -2072,7 +2072,7 @@ interface BodyIDVector {
 interface PhysicsSystem {
 	void SetGravity([Const, Ref] Vec3 inGravity);
 	[Value] Vec3 GetGravity();
-	[Const, Value] PhysicsSettings GetPhysicsSettings();
+	[Const, Ref] PhysicsSettings GetPhysicsSettings();
 	void SetPhysicsSettings([Const, Ref] PhysicsSettings inPhysicsSettings);
 	unsigned long GetNumBodies();
 	unsigned long GetNumActiveBodies(EBodyType inBodyType);


### PR DESCRIPTION
The included `Body.GetID()` solves the issue of:

```javascript
const box1 = createBox
const bodyID1 = box1.GetID()
const box2 = createBox
const bodyID2 = box2.GetID()

bodyID1.GetIndexAndSequenceNumber() == bodyID2.GetIndexAndSequenceNumber()
```

I think I'm in the habit of only ever using `.GetID().GetIndexAndSequenceNumber();` so hadn't run into this yet