### PR TITLE
Soft Body Demos - Pressure Spheres, Volume Cubes, new Auto Constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ include(FetchContent)
 FetchContent_Declare(
         JoltPhysics
         GIT_REPOSITORY "https://github.com/jrouwe/JoltPhysics"
-        GIT_TAG "e64724e907ba26acebf9739e4c41483dfb79152d"
+        GIT_TAG "f2d1175432f8225450dea252322ba2dbaa83a370" #v5.0.0
 		SOURCE_SUBDIR "Build"
 )
 FetchContent_MakeAvailable(JoltPhysics)

--- a/Examples/index.html
+++ b/Examples/index.html
@@ -7,7 +7,13 @@
 		<h1><a href="https://github.com/jrouwe/JoltPhysics.js">JoltPhysics.js</a> demos</h1>
 		<ul>
 			<li><a href="falling_shapes.html">Falling Shapes Demo</a> - Shows supported shape types</li>
-			<li><a href="soft_body.html">Soft Body Demo</a> - Shows a soft body cloth</li>
+			<li><a href="soft/soft_body.html">Soft Body Demo</a> - Shows a soft body cloth</li>
+			<li><a href="soft/soft_cubes.html">Soft Cube Demo</a> - Shows soft volume-constrained cubes</li>
+			<li><a href="soft/soft_friction.html">Soft Friction Demo</a> - Shows effect of friction on soft cubes and spheres</li>
+			<li><a href="soft/soft_gravity.html">Soft Gravity Demo</a> - Shows effect of GravityFactor on soft cubes and spheres</li>
+			<li><a href="soft/soft_sphere_pressure.html">Soft Sphere Pressure</a> - Shows effect of various levels of Pressure on soft spheres</li>
+			<li><a href="soft/soft_bend_constraint.html">Soft Bend Constraint</a> - Shows effect of bend constraint on soft cloth and spheres</li>
+			<li><a href="soft/soft_lra_constraint.html">Soft LRA Constraint</a> - Shows effect of LRA constraint on soft cloth</li>
 			<li><a href="vehicle_wheeled.html">Wheeled Vehicle Controller Demo</a> - Shows how to create a multi-wheel vehicle</li>
 			<li><a href="vehicle_motorcycle.html">Motorcycle Controller Demo</a> - Shows how to create a motorcycle vehicle</li>
 			<li><a href="vehicle_tank.html">Tank Controller Demo</a> - Shows how to create a tank vehicle</li>

--- a/Examples/js/example.js
+++ b/Examples/js/example.js
@@ -171,7 +171,7 @@ function renderExample() {
 		objThree.quaternion.copy(wrapQuat(body.GetRotation()));
 
 		if (body.GetBodyType() == Jolt.EBodyType_SoftBody) {
-			if(objThree.userData.updateVertex) {
+			if (objThree.userData.updateVertex) {
 				objThree.userData.updateVertex();
 			} else {
 				objThree.geometry = createMeshForShape(body.GetShape());
@@ -275,21 +275,20 @@ function getSoftBodyMesh(body, material) {
 	// where current Position is both F32 and located 16 bytes into SoftBodyVertex
 	function memoryMapVertex(i) {
 		const offset = Jolt.getPointer(vertexSettings.at(i));
-		return new Float32Array(Jolt.HEAPF32.buffer, 16+ offset, 3);
+		return new Float32Array(Jolt.HEAPF32.buffer, 16 + offset, 3);
 	}
 
-	for(let i=0;i<faceData.size(); i++) {
+	for (let i = 0; i < faceData.size(); i++) {
 		const [v0, v1, v2] = new Uint32Array(Jolt.HEAP32.buffer, Jolt.getPointer(faceData.at(i)), 3);
 		softVertex.push(memoryMapVertex(v0))
 		softVertex.push(memoryMapVertex(v1))
 		softVertex.push(memoryMapVertex(v2))
 	}
 
-
 	// Get a view on the triangle data (does not make a copy)
-	let vertices = new Float32Array(settings.mFaces.size()*9);
-	for(let i=0;i<softVertex.length;i++) {
-		vertices.set(softVertex[i], i*3);
+	let vertices = new Float32Array(settings.mFaces.size() * 9);
+	for (let i = 0; i < softVertex.length; i++) {
+		vertices.set(softVertex[i], i * 3);
 	}
 
 	let buffer = new THREE.BufferAttribute(vertices, 3);
@@ -302,13 +301,12 @@ function getSoftBodyMesh(body, material) {
 	material.side = THREE.DoubleSide;
 	const threeObject = new THREE.Mesh(geometry, material);
 	threeObject.userData.updateVertex = () => {
-		for(let i=0;i<softVertex.length;i++) {
-			vertices.set(softVertex[i], i*3);
+		for (let i = 0; i < softVertex.length; i++) {
+			vertices.set(softVertex[i], i * 3);
 		}
 		geometry.computeVertexNormals();
 		geometry.getAttribute('position').needsUpdate = true;
 		geometry.getAttribute('normal').needsUpdate = true;
-
 	}
 	return threeObject;
 }

--- a/Examples/js/example.js
+++ b/Examples/js/example.js
@@ -267,15 +267,15 @@ function getSoftBodyMesh(body, material) {
 	const motionProperties = Jolt.castObject(body.GetMotionProperties(), Jolt.SoftBodyMotionProperties);
 	const vertexSettings = motionProperties.GetVertices();
 	const settings = motionProperties.GetSettings();
+	const positionOffset = Jolt.SoftBodyVertexTraits.prototype.mPositionOffset;
 
 	const faceData = settings.mFaces;
 	const softVertex = [];
 
-	// WARNING; Direct memory mapping to soft vertex positions ties this code to specific builds of Jolt
-	// where current Position is both F32 and located 16 bytes into SoftBodyVertex
+	// WARNING: The code uses direct memory mapping of properties in Jolt and makes assumptions about the memory layout.
 	function memoryMapVertex(i) {
 		const offset = Jolt.getPointer(vertexSettings.at(i));
-		return new Float32Array(Jolt.HEAPF32.buffer, 16 + offset, 3);
+		return new Float32Array(Jolt.HEAPF32.buffer, offset + positionOffset, 3);
 	}
 
 	for (let i = 0; i < faceData.size(); i++) {

--- a/Examples/js/soft-body-creator.js
+++ b/Examples/js/soft-body-creator.js
@@ -2,6 +2,7 @@ class SoftBodyCreator {
 	static CreateCloth(inGridSizeX = 30, inGridSizeZ = 30, inGridSpacing = 0.75, inVertexGetInvMass = (_x, _y) => 1, inVertexPerturbation = (_x, _z) => ({ x: 0, y: 0, z: 0 }), inBendType = Jolt.SoftBodySharedSettings_EBendType_None, inVertexAttributes) {
 		const cOffsetX = -0.5 * inGridSpacing * (inGridSizeX - 1);
 		const cOffsetZ = -0.5 * inGridSpacing * (inGridSizeZ - 1);
+
 		// Create settings
 		const sharedSettings = new Jolt.SoftBodySharedSettings;
 		const v = new Jolt.SoftBodySharedSettingsVertex;
@@ -15,11 +16,13 @@ class SoftBodyCreator {
 				sharedSettings.mVertices.push_back(v);
 			}
 		Jolt.destroy(v);
+
 		// Function to get the vertex index of a point on the cloth
 		function vertex_index(inX, inY) {
 			return inX + inY * inGridSizeX;
 		}
 		sharedSettings.CalculateEdgeLengths();
+
 		// Create faces
 		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
 		for (let z = 0; z < inGridSizeZ - 1; ++z)
@@ -33,10 +36,10 @@ class SoftBodyCreator {
 				sharedSettings.AddFace(f);
 			}
 		Jolt.destroy(f);
+
 		if (inVertexAttributes) {
 			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
-		}
-		else {
+		} else {
 			const inVertexAttributes = new Jolt.SoftBodySharedSettingsVertexAttributes();
 			inVertexAttributes.mCompliance = 1.0e-5;
 			inVertexAttributes.mShearCompliance = 1.0e-5;
@@ -44,22 +47,26 @@ class SoftBodyCreator {
 			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
 			Jolt.destroy(inVertexAttributes);
 		}
+
 		// Optimize the settings
 		sharedSettings.Optimize();
 		return sharedSettings;
 	}
+
 	static CreateClothWithFixatedCorners(inGridSizeX = 30, inGridSizeZ = 30, inGridSpacing = 0.75) {
 		function inv_mass(inX, inZ) {
 			return (inX == 0 && inZ == 0)
 				|| (inX == inGridSizeX - 1 && inZ == 0)
 				|| (inX == 0 && inZ == inGridSizeZ - 1)
 				|| (inX == inGridSizeX - 1 && inZ == inGridSizeZ - 1) ? 0.0 : 1.0;
-		}
-		;
+		};
+
 		return this.CreateCloth(inGridSizeX, inGridSizeZ, inGridSpacing, inv_mass);
 	}
+
 	static CreateCube(inGridSize = 5, inGridSpacing = 0.5, edgeCompliance = 0, volumeCompliance = 0) {
 		const cOffset = -0.5 * inGridSpacing * (inGridSize - 1);
+
 		// Create settings
 		const sharedSettings = new Jolt.SoftBodySharedSettings;
 		const v = new Jolt.SoftBodySharedSettingsVertex;
@@ -72,12 +79,14 @@ class SoftBodyCreator {
 					sharedSettings.mVertices.push_back(v);
 				}
 		Jolt.destroy(v);
+
 		// Function to get the vertex index of a point on the cloth
 		const vertex_index = (inX, inY, inZ) => {
 			return inX + inY * inGridSize + inZ * inGridSize * inGridSize;
 		};
 		const sEdge = new Jolt.SoftBodySharedSettingsEdge(0, 0, 0);
 		sEdge.mCompliance = edgeCompliance;
+
 		// Create edges
 		for (let z = 0; z < inGridSize; ++z)
 			for (let y = 0; y < inGridSize; ++y)
@@ -102,6 +111,7 @@ class SoftBodyCreator {
 				}
 		Jolt.destroy(sEdge);
 		sharedSettings.CalculateEdgeLengths();
+
 		const tetra_indices = [
 			[[0, 0, 0], [0, 1, 1], [0, 0, 1], [1, 1, 1]],
 			[[0, 0, 0], [0, 1, 0], [0, 1, 1], [1, 1, 1]],
@@ -110,6 +120,7 @@ class SoftBodyCreator {
 			[[0, 0, 0], [1, 1, 0], [0, 1, 0], [1, 1, 1]],
 			[[0, 0, 0], [1, 0, 0], [1, 1, 0], [1, 1, 1]]
 		];
+
 		// Create volume constraints
 		const sVol = new Jolt.SoftBodySharedSettingsVolume(0, 0, 0, 0, 0);
 		sVol.mCompliance = volumeCompliance;
@@ -123,6 +134,7 @@ class SoftBodyCreator {
 					}
 		Jolt.destroy(sVol);
 		sharedSettings.CalculateVolumeConstraintVolumes();
+
 		// Create faces
 		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
 		for (let y = 0; y < inGridSize - 1; ++y)
@@ -177,13 +189,16 @@ class SoftBodyCreator {
 				sharedSettings.AddFace(f);
 			}
 		Jolt.destroy(f);
+
 		// Optimize the settings
 		sharedSettings.Optimize();
 		return sharedSettings;
 	}
+
 	static CreateSphere(inRadius = 1, inNumTheta = 10, inNumPhi = 20, inBendType = Jolt.SoftBodySharedSettings_EBendType_None, inVertexAttributes) {
 		const sharedSettings = new Jolt.SoftBodySharedSettings;
 		const v3 = new window.THREE.Vector3();
+
 		// Create settings
 		// NOTE: This is not how you should create a soft body sphere, we explicitly use polar coordinates to make the vertices unevenly distributed.
 		// Doing it this way tests the pressure algorithm as it receives non-uniform triangles. Better is to use uniform triangles,
@@ -202,6 +217,7 @@ class SoftBodyCreator {
 				sUnitSpherical(Math.PI * theta / (inNumTheta - 1), 2.0 * Math.PI * phi / inNumPhi);
 			}
 		Jolt.destroy(v);
+
 		function vertex_index(inTheta, inPhi) {
 			if (inTheta == 0)
 				return 0;
@@ -210,7 +226,6 @@ class SoftBodyCreator {
 			else
 				return 2 + (inTheta - 1) * inNumPhi + inPhi % inNumPhi;
 		}
-		sharedSettings.CalculateEdgeLengths();
 		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
 		for (let phi = 0; phi < inNumPhi; ++phi) {
 			for (let theta = 0; theta < inNumTheta - 2; ++theta) {
@@ -230,10 +245,10 @@ class SoftBodyCreator {
 			sharedSettings.AddFace(f);
 		}
 		Jolt.destroy(f);
+
 		if (inVertexAttributes) {
 			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
-		}
-		else {
+		} else {
 			const inVertexAttributes = new Jolt.SoftBodySharedSettingsVertexAttributes();
 			inVertexAttributes.mCompliance = 1.0e-4;
 			inVertexAttributes.mShearCompliance = 1.0e-4;
@@ -241,6 +256,7 @@ class SoftBodyCreator {
 			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
 			Jolt.destroy(inVertexAttributes);
 		}
+
 		// Optimize the settings
 		sharedSettings.Optimize();
 		return sharedSettings;

--- a/Examples/js/soft-body-creator.js
+++ b/Examples/js/soft-body-creator.js
@@ -1,0 +1,248 @@
+class SoftBodyCreator {
+	static CreateCloth(inGridSizeX = 30, inGridSizeZ = 30, inGridSpacing = 0.75, inVertexGetInvMass = (_x, _y) => 1, inVertexPerturbation = (_x, _z) => ({ x: 0, y: 0, z: 0 }), inBendType = Jolt.SoftBodySharedSettings_EBendType_None, inVertexAttributes) {
+		const cOffsetX = -0.5 * inGridSpacing * (inGridSizeX - 1);
+		const cOffsetZ = -0.5 * inGridSpacing * (inGridSizeZ - 1);
+		// Create settings
+		const sharedSettings = new Jolt.SoftBodySharedSettings;
+		const v = new Jolt.SoftBodySharedSettingsVertex;
+		for (let z = 0; z < inGridSizeZ; ++z)
+			for (let x = 0; x < inGridSizeX; ++x) {
+				const perturb = inVertexPerturbation(x, z);
+				v.mPosition.x = inGridSpacing * x + cOffsetX + perturb.x;
+				v.mPosition.y = 0 + perturb.y;
+				v.mPosition.z = inGridSpacing * z + cOffsetZ + perturb.z;
+				v.mInvMass = inVertexGetInvMass(x, z);
+				sharedSettings.mVertices.push_back(v);
+			}
+		Jolt.destroy(v);
+		// Function to get the vertex index of a point on the cloth
+		function vertex_index(inX, inY) {
+			return inX + inY * inGridSizeX;
+		}
+		sharedSettings.CalculateEdgeLengths();
+		// Create faces
+		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
+		for (let z = 0; z < inGridSizeZ - 1; ++z)
+			for (let x = 0; x < inGridSizeX - 1; ++x) {
+				f.set_mVertex(0, vertex_index(x, z));
+				f.set_mVertex(1, vertex_index(x, z + 1));
+				f.set_mVertex(2, vertex_index(x + 1, z + 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(x + 1, z + 1));
+				f.set_mVertex(2, vertex_index(x + 1, z));
+				sharedSettings.AddFace(f);
+			}
+		Jolt.destroy(f);
+		if (inVertexAttributes) {
+			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
+		}
+		else {
+			const inVertexAttributes = new Jolt.SoftBodySharedSettingsVertexAttributes();
+			inVertexAttributes.mCompliance = 1.0e-5;
+			inVertexAttributes.mShearCompliance = 1.0e-5;
+			inVertexAttributes.mBendCompliance = 1.0e-5;
+			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
+			Jolt.destroy(inVertexAttributes);
+		}
+		// Optimize the settings
+		sharedSettings.Optimize();
+		return sharedSettings;
+	}
+	static CreateClothWithFixatedCorners(inGridSizeX = 30, inGridSizeZ = 30, inGridSpacing = 0.75) {
+		function inv_mass(inX, inZ) {
+			return (inX == 0 && inZ == 0)
+				|| (inX == inGridSizeX - 1 && inZ == 0)
+				|| (inX == 0 && inZ == inGridSizeZ - 1)
+				|| (inX == inGridSizeX - 1 && inZ == inGridSizeZ - 1) ? 0.0 : 1.0;
+		}
+		;
+		return this.CreateCloth(inGridSizeX, inGridSizeZ, inGridSpacing, inv_mass);
+	}
+	static CreateCube(inGridSize = 5, inGridSpacing = 0.5, edgeCompliance = 0, volumeCompliance = 0) {
+		const cOffset = -0.5 * inGridSpacing * (inGridSize - 1);
+		// Create settings
+		const sharedSettings = new Jolt.SoftBodySharedSettings;
+		const v = new Jolt.SoftBodySharedSettingsVertex;
+		for (let z = 0; z < inGridSize; ++z)
+			for (let y = 0; y < inGridSize; ++y)
+				for (let x = 0; x < inGridSize; ++x) {
+					v.mPosition.x = inGridSpacing * x + cOffset;
+					v.mPosition.y = inGridSpacing * y + cOffset;
+					v.mPosition.z = inGridSpacing * z + cOffset;
+					sharedSettings.mVertices.push_back(v);
+				}
+		Jolt.destroy(v);
+		// Function to get the vertex index of a point on the cloth
+		const vertex_index = (inX, inY, inZ) => {
+			return inX + inY * inGridSize + inZ * inGridSize * inGridSize;
+		};
+		const sEdge = new Jolt.SoftBodySharedSettingsEdge(0, 0, 0);
+		sEdge.mCompliance = edgeCompliance;
+		// Create edges
+		for (let z = 0; z < inGridSize; ++z)
+			for (let y = 0; y < inGridSize; ++y)
+				for (let x = 0; x < inGridSize; ++x) {
+					const v0 = vertex_index(x, y, z);
+					sEdge.set_mVertex(0, v0);
+					if (x < inGridSize - 1) {
+						const v1 = vertex_index(x + 1, y, z);
+						sEdge.set_mVertex(1, v1);
+						sharedSettings.mEdgeConstraints.push_back(sEdge);
+					}
+					if (y < inGridSize - 1) {
+						const v1 = vertex_index(x, y + 1, z);
+						sEdge.set_mVertex(1, v1);
+						sharedSettings.mEdgeConstraints.push_back(sEdge);
+					}
+					if (z < inGridSize - 1) {
+						const v1 = vertex_index(x, y, z + 1);
+						sEdge.set_mVertex(1, v1);
+						sharedSettings.mEdgeConstraints.push_back(sEdge);
+					}
+				}
+		Jolt.destroy(sEdge);
+		sharedSettings.CalculateEdgeLengths();
+		const tetra_indices = [
+			[[0, 0, 0], [0, 1, 1], [0, 0, 1], [1, 1, 1]],
+			[[0, 0, 0], [0, 1, 0], [0, 1, 1], [1, 1, 1]],
+			[[0, 0, 0], [0, 0, 1], [1, 0, 1], [1, 1, 1]],
+			[[0, 0, 0], [1, 0, 1], [1, 0, 0], [1, 1, 1]],
+			[[0, 0, 0], [1, 1, 0], [0, 1, 0], [1, 1, 1]],
+			[[0, 0, 0], [1, 0, 0], [1, 1, 0], [1, 1, 1]]
+		];
+		// Create volume constraints
+		const sVol = new Jolt.SoftBodySharedSettingsVolume(0, 0, 0, 0, 0);
+		sVol.mCompliance = volumeCompliance;
+		for (let z = 0; z < inGridSize - 1; ++z)
+			for (let y = 0; y < inGridSize - 1; ++y)
+				for (let x = 0; x < inGridSize - 1; ++x)
+					for (let t = 0; t < 6; ++t) {
+						for (let i = 0; i < 4; ++i)
+							sVol.set_mVertex(i, vertex_index(x + tetra_indices[t][i][0], y + tetra_indices[t][i][1], z + tetra_indices[t][i][2]));
+						sharedSettings.mVolumeConstraints.push_back(sVol);
+					}
+		Jolt.destroy(sVol);
+		sharedSettings.CalculateVolumeConstraintVolumes();
+		// Create faces
+		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
+		for (let y = 0; y < inGridSize - 1; ++y)
+			for (let x = 0; x < inGridSize - 1; ++x) {
+				// Face 1
+				f.set_mVertex(0, vertex_index(x, y, 0));
+				f.set_mVertex(1, vertex_index(x, y + 1, 0));
+				f.set_mVertex(2, vertex_index(x + 1, y + 1, 0));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(x + 1, y + 1, 0));
+				f.set_mVertex(2, vertex_index(x + 1, y, 0));
+				sharedSettings.AddFace(f);
+				// Face 2
+				f.set_mVertex(0, vertex_index(x, y, inGridSize - 1));
+				f.set_mVertex(1, vertex_index(x + 1, y + 1, inGridSize - 1));
+				f.set_mVertex(2, vertex_index(x, y + 1, inGridSize - 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(x + 1, y, inGridSize - 1));
+				f.set_mVertex(2, vertex_index(x + 1, y + 1, inGridSize - 1));
+				sharedSettings.AddFace(f);
+				// Face 3
+				f.set_mVertex(0, vertex_index(x, 0, y));
+				f.set_mVertex(1, vertex_index(x + 1, 0, y + 1));
+				f.set_mVertex(2, vertex_index(x, 0, y + 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(x + 1, 0, y));
+				f.set_mVertex(2, vertex_index(x + 1, 0, y + 1));
+				sharedSettings.AddFace(f);
+				// Face 4
+				f.set_mVertex(0, vertex_index(x, inGridSize - 1, y));
+				f.set_mVertex(1, vertex_index(x, inGridSize - 1, y + 1));
+				f.set_mVertex(2, vertex_index(x + 1, inGridSize - 1, y + 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(x + 1, inGridSize - 1, y + 1));
+				f.set_mVertex(2, vertex_index(x + 1, inGridSize - 1, y));
+				sharedSettings.AddFace(f);
+				// Face 5
+				f.set_mVertex(0, vertex_index(0, x, y));
+				f.set_mVertex(1, vertex_index(0, x, y + 1));
+				f.set_mVertex(2, vertex_index(0, x + 1, y + 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(0, x + 1, y + 1));
+				f.set_mVertex(2, vertex_index(0, x + 1, y));
+				sharedSettings.AddFace(f);
+				// Face 6
+				f.set_mVertex(0, vertex_index(inGridSize - 1, x, y));
+				f.set_mVertex(1, vertex_index(inGridSize - 1, x + 1, y + 1));
+				f.set_mVertex(2, vertex_index(inGridSize - 1, x, y + 1));
+				sharedSettings.AddFace(f);
+				f.set_mVertex(1, vertex_index(inGridSize - 1, x + 1, y));
+				f.set_mVertex(2, vertex_index(inGridSize - 1, x + 1, y + 1));
+				sharedSettings.AddFace(f);
+			}
+		Jolt.destroy(f);
+		// Optimize the settings
+		sharedSettings.Optimize();
+		return sharedSettings;
+	}
+	static CreateSphere(inRadius = 1, inNumTheta = 10, inNumPhi = 20, inBendType = Jolt.SoftBodySharedSettings_EBendType_None, inVertexAttributes) {
+		const sharedSettings = new Jolt.SoftBodySharedSettings;
+		const v3 = new window.THREE.Vector3();
+		// Create settings
+		// NOTE: This is not how you should create a soft body sphere, we explicitly use polar coordinates to make the vertices unevenly distributed.
+		// Doing it this way tests the pressure algorithm as it receives non-uniform triangles. Better is to use uniform triangles,
+		const v = new Jolt.SoftBodySharedSettingsVertex;
+		function sUnitSpherical(phi, theta) {
+			v3.setFromSphericalCoords(inRadius, phi, theta);
+			v.mPosition.x = v3.x;
+			v.mPosition.y = v3.y;
+			v.mPosition.z = v3.z;
+			sharedSettings.mVertices.push_back(v);
+		}
+		sUnitSpherical(0, 0);
+		sUnitSpherical(Math.PI, 0);
+		for (let theta = 1; theta < inNumTheta - 1; ++theta)
+			for (let phi = 0; phi < inNumPhi; ++phi) {
+				sUnitSpherical(Math.PI * theta / (inNumTheta - 1), 2.0 * Math.PI * phi / inNumPhi);
+			}
+		Jolt.destroy(v);
+		function vertex_index(inTheta, inPhi) {
+			if (inTheta == 0)
+				return 0;
+			else if (inTheta == inNumTheta - 1)
+				return 1;
+			else
+				return 2 + (inTheta - 1) * inNumPhi + inPhi % inNumPhi;
+		}
+		sharedSettings.CalculateEdgeLengths();
+		const f = new Jolt.SoftBodySharedSettingsFace(0, 0, 0, 0);
+		for (let phi = 0; phi < inNumPhi; ++phi) {
+			for (let theta = 0; theta < inNumTheta - 2; ++theta) {
+				f.set_mVertex(0, vertex_index(theta, phi));
+				f.set_mVertex(1, vertex_index(theta + 1, phi));
+				f.set_mVertex(2, vertex_index(theta + 1, phi + 1));
+				sharedSettings.AddFace(f);
+				if (theta > 0) {
+					f.set_mVertex(1, vertex_index(theta + 1, phi + 1));
+					f.set_mVertex(2, vertex_index(theta, phi + 1));
+					sharedSettings.AddFace(f);
+				}
+			}
+			f.set_mVertex(0, vertex_index(inNumTheta - 2, phi + 1));
+			f.set_mVertex(1, vertex_index(inNumTheta - 2, phi));
+			f.set_mVertex(2, vertex_index(inNumTheta - 1, 0));
+			sharedSettings.AddFace(f);
+		}
+		Jolt.destroy(f);
+		if (inVertexAttributes) {
+			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
+		}
+		else {
+			const inVertexAttributes = new Jolt.SoftBodySharedSettingsVertexAttributes();
+			inVertexAttributes.mCompliance = 1.0e-4;
+			inVertexAttributes.mShearCompliance = 1.0e-4;
+			inVertexAttributes.mBendCompliance = 1.0e-3;
+			sharedSettings.CreateConstraints(inVertexAttributes, 1, inBendType);
+			Jolt.destroy(inVertexAttributes);
+		}
+		// Optimize the settings
+		sharedSettings.Optimize();
+		return sharedSettings;
+	}
+}

--- a/Examples/soft/soft_bend_constraint.html
+++ b/Examples/soft/soft_bend_constraint.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js Soft Bend Constraint<br /> Red: Bend Type None<br/> Green: Bend Type Distance<br/> Blue: Bend Type Dihedral</div>
+		<div id="info">JoltPhysics.js Soft Bend Constraint<br /> Red: Bend Type None<br /> Green: Bend Type Distance<br /> Blue: Bend Type Dihedral</div>
 
 		<script src="../js/three/three.min.js"></script>
 		<script src="../js/three/OrbitControls.js"></script>
@@ -18,37 +18,37 @@
 		<script src="../js/soft-body-creator.js"></script>
 
 		<script type="module">
-			
+
 			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
 			import initJolt from '../js/jolt-physics.wasm-compat.js';
 			function xorshift32(a) {
 				a = new Uint32Array([a]);
-				return function() {
+				return function () {
 					let x = a[0];
 					x ^= x << 13;
 					x ^= x >> 17;
 					x ^= x << 5;
 					a[0] = x;
-					return a[0]/0xFFFFFFFF;
+					return a[0] / 0xFFFFFFFF;
 				}
 			}
 
 			const cNumVerticesX = 10;
-			const	cNumVerticesZ = 10;
-			const	cVertexSpacing = 0.5;
+			const cNumVerticesZ = 10;
+			const cVertexSpacing = 0.5;
 
 			initJolt().then(async function (Jolt) {
 				// Initialize this example
 				initExample(Jolt, null);
 
 				createFloor();
-				const inv_mass = (x, z) => z < 2 ? 0: 1;
+				const inv_mass = (x, z) => z < 2 ? 0 : 1;
 				const random_float = (v) => 0.2 * v - 0.1;
 				const perturbation = (seed) => {
 					const random = xorshift32(seed);
 					return (_x, inZ) => ({
 						x: random_float(random()),
-						y: inZ & 1? 0.1 : -0.1,
+						y: inZ & 1 ? 0.1 : -0.1,
 						z: random_float(random())
 					});
 				}

--- a/Examples/soft/soft_bend_constraint.html
+++ b/Examples/soft/soft_bend_constraint.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft Bend Constraint<br /> Red: Bend Type None<br/> Green: Bend Type Distance<br/> Blue: Bend Type Dihedral</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+			function xorshift32(a) {
+				a = new Uint32Array([a]);
+				return function() {
+					let x = a[0];
+					x ^= x << 13;
+					x ^= x >> 17;
+					x ^= x << 5;
+					a[0] = x;
+					return a[0]/0xFFFFFFFF;
+				}
+			}
+
+			const cNumVerticesX = 10;
+			const	cNumVerticesZ = 10;
+			const	cVertexSpacing = 0.5;
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+
+				createFloor();
+				const inv_mass = (x, z) => z < 2 ? 0: 1;
+				const random_float = (v) => 0.2 * v - 0.1;
+				const perturbation = (seed) => {
+					const random = xorshift32(seed);
+					return (_x, inZ) => ({
+						x: random_float(random()),
+						y: inZ & 1? 0.1 : -0.1,
+						z: random_float(random())
+					});
+				}
+
+				const rotation = Jolt.Quat.prototype.sIdentity();
+				const position = new Jolt.RVec3();
+
+				const COLOR_NONE = 0xaa0000;
+				const COLOR_DISTANCE = 0x00aa00;
+				const COLOR_DIHEDRAL = 0x0000aa;
+				{
+
+					// Cloth without bend constraints
+					const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_None);
+					position.Set(-5, 5, 0);
+					const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(cloth);
+					addToScene(body, COLOR_NONE);
+				}
+
+				{
+					// Cloth with distance bend constraints
+					const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_Distance);
+					position.Set(0, 5, 0);
+					const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(cloth);
+					addToScene(body, COLOR_DISTANCE);
+				}
+
+				{
+					// Cloth with dihedral bend constraints
+					const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_Dihedral);
+					position.Set(5, 5, 0);
+					const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(cloth);
+					addToScene(body, COLOR_DIHEDRAL);
+				}
+
+				{
+					// Create sphere
+					const sphere_settings = SoftBodyCreator.CreateSphere(1.0, 10, 20, Jolt.SoftBodySharedSettings_EBendType_None)
+					position.Set(-5, 5, 10);
+					const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, position, rotation, LAYER_MOVING);
+
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, COLOR_NONE);
+				}
+
+				{
+					// Create sphere with distance bend constraints
+					const sphere_settings = SoftBodyCreator.CreateSphere(1.0, 10, 20, Jolt.SoftBodySharedSettings_EBendType_Distance);
+					position.Set(0, 5, 10);
+					const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, COLOR_DISTANCE);
+				}
+
+				{
+					// Create sphere with dihedral bend constraints
+					const sphere_settings = SoftBodyCreator.CreateSphere(1.0, 10, 20, Jolt.SoftBodySharedSettings_EBendType_Dihedral);
+					position.Set(5, 5, 10);
+					const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, COLOR_DIHEDRAL);
+				}
+
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_body.html
+++ b/Examples/soft/soft_body.html
@@ -4,7 +4,7 @@
 		<title>JoltPhysics.js demo</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link rel="stylesheet" type="text/css" href="style.css">
+		<link rel="stylesheet" type="text/css" href="../style.css">
 	</head>
 	<body>
 		<div id="container">Loading...</div>
@@ -12,15 +12,15 @@
 			<input type="checkbox" id="show-particles"><label>Show soft body particles</label>
 		</div>
 
-		<script src="js/three/three.min.js"></script>
-		<script src="js/three/OrbitControls.js"></script>
-		<script src="js/three/WebGL.js"></script>
-		<script src="js/three/stats.min.js"></script>
-		<script src="js/example.js"></script>
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
 
 		<script type="module">
 			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
-			import initJolt from './js/jolt-physics.wasm-compat.js';
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
 
 			let markers = null;
 

--- a/Examples/soft/soft_cubes.html
+++ b/Examples/soft/soft_cubes.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js Soft Cubes<br />Edge compliance strength on X Axis, stronger towards right<br/> Volume compliance strength on Z axis, stronger towards camera</div>
+		<div id="info">JoltPhysics.js Soft Cubes<br />Edge compliance strength on X Axis, stronger towards right<br /> Volume compliance strength on Z axis, stronger towards camera</div>
 
 		<script src="../js/three/three.min.js"></script>
 		<script src="../js/three/OrbitControls.js"></script>
@@ -49,7 +49,7 @@
 				checkerTexture.magFilter = window.THREE.NearestFilter;
 
 				createFloor();
-				const floor = dynamicObjects[dynamicObjects.length-1];
+				const floor = dynamicObjects[dynamicObjects.length - 1];
 				let checkerMat = new window.THREE.MeshPhongMaterial({ color: 0xdddddd });
 				checkerMat.map = checkerTexture;
 				floor.material = checkerMat;
@@ -60,7 +60,7 @@
 				const position = new Jolt.RVec3();
 				const rotAxis = new Jolt.Vec3(1, 0, 0);
 				const rotation = Jolt.Quat.prototype.sRotation(rotAxis, -Math.PI / 4);
-				
+
 				function createGelCube(edgeCompliance, volumeCompliance, x, y, z, color) {
 					// Create shared settings
 					const sharedSettings = SoftBodyCreator.CreateCube(8, 0.2, edgeCompliance, volumeCompliance);
@@ -73,19 +73,19 @@
 
 					Jolt.destroy(bodyCreationSettings);
 
-					const mesh = dynamicObjects[dynamicObjects.length-1];
+					const mesh = dynamicObjects[dynamicObjects.length - 1];
 					const jellyMaterial = new window.THREE.MeshPhysicalMaterial(jelly);
-					const [r,g,b] = color;
-					jellyMaterial.attenuationColor.setRGB(r,g,b);
+					const [r, g, b] = color;
+					jellyMaterial.attenuationColor.setRGB(r, g, b);
 					mesh.material = jellyMaterial;
 				}
 
 				// Compliance in constraints are calculated here in 10^negative values and are inverse-values, so closer to 0 is closer to infinity
 				// These will be very, very small floating values to maintain cube-like structure
 				// Most values of even 10e-3 (0.0001) are too large to maintain structural integrity and we need to go even smaller towards -7 or -8
-				for(let y = 0; y < 4; y++)
-				for(let x = 0; x < 4; x++)
-				createGelCube( Math.pow(10,-3-y), Math.pow(10,-5-x),-10+x*5, 12, -10+y*5, [0.7 + 0.1*y, 0.7+x*.1, 1-y*0.1]);
+				for (let y = 0; y < 4; y++)
+					for (let x = 0; x < 4; x++)
+						createGelCube(Math.pow(10, -3 - y), Math.pow(10, -5 - x), -10 + x * 5, 12, -10 + y * 5, [0.7 + 0.1 * y, 0.7 + x * .1, 1 - y * 0.1]);
 			});
 		</script>
 	</body>

--- a/Examples/soft/soft_cubes.html
+++ b/Examples/soft/soft_cubes.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft Cubes<br />Edge compliance strength on X Axis, stronger towards right<br/> Volume compliance strength on Z axis, stronger towards camera</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+
+			const jelly = {
+				color: 0xffffff,
+				transmission: 0.9,
+				opacity: 0.7,
+				metalness: 0,
+				roughness: 0.2,
+				ior: 2.5,
+				thickness: 2.5,
+				attenuationColor: 0xffffff,
+				attenuationDistance: 0.25,
+				specularIntensity: 1,
+				specularColor: 0xffffff,
+				lightIntensity: 1,
+				exposure: 1
+			};
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+
+				const texLoader = new window.THREE.TextureLoader();
+				const checkerTexture = texLoader.load('data:image/gif;base64,R0lGODdhAgACAIABAAAAAP///ywAAAAAAgACAAACA0QCBQA7');
+				checkerTexture.wrapS = checkerTexture.wrapT = window.THREE.RepeatWrapping;
+				checkerTexture.offset.set(0, 0);
+				checkerTexture.repeat.set(10, 10);
+				checkerTexture.magFilter = window.THREE.NearestFilter;
+
+				createFloor();
+				const floor = dynamicObjects[dynamicObjects.length-1];
+				let checkerMat = new window.THREE.MeshPhongMaterial({ color: 0xdddddd });
+				checkerMat.map = checkerTexture;
+				floor.material = checkerMat;
+
+				camera.position.y -= 4;
+				camera.position.z -= 4;
+
+				const position = new Jolt.RVec3();
+				const rotAxis = new Jolt.Vec3(1, 0, 0);
+				const rotation = Jolt.Quat.prototype.sRotation(rotAxis, -Math.PI / 4);
+				
+				function createGelCube(edgeCompliance, volumeCompliance, x, y, z, color) {
+					// Create shared settings
+					const sharedSettings = SoftBodyCreator.CreateCube(8, 0.2, edgeCompliance, volumeCompliance);
+					position.Set(x, y, z)
+					const bodyCreationSettings = new Jolt.SoftBodyCreationSettings(sharedSettings, position, rotation, LAYER_MOVING);
+					bodyCreationSettings.mPressure = 2;
+					bodyCreationSettings.mObjectLayer = LAYER_MOVING;
+					const body = bodyInterface.CreateSoftBody(bodyCreationSettings);
+					addToScene(body, 0xffffff);
+
+					Jolt.destroy(bodyCreationSettings);
+
+					const mesh = dynamicObjects[dynamicObjects.length-1];
+					const jellyMaterial = new window.THREE.MeshPhysicalMaterial(jelly);
+					const [r,g,b] = color;
+					jellyMaterial.attenuationColor.setRGB(r,g,b);
+					mesh.material = jellyMaterial;
+				}
+
+				// Compliance in constraints are calculated here in 10^negative values and are inverse-values, so closer to 0 is closer to infinity
+				// These will be very, very small floating values to maintain cube-like structure
+				// Most values of even 10e-3 (0.0001) are too large to maintain structural integrity and we need to go even smaller towards -7 or -8
+				for(let y = 0; y < 4; y++)
+				for(let x = 0; x < 4; x++)
+				createGelCube( Math.pow(10,-3-y), Math.pow(10,-5-x),-10+x*5, 12, -10+y*5, [0.7 + 0.1*y, 0.7+x*.1, 1-y*0.1]);
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_friction.html
+++ b/Examples/soft/soft_friction.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft Body Friction<br /> Friction increases, Left to Right</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+				camera.position.z += 40;
+
+				const floor = createFloor();
+				floor.SetFriction(1.0);
+
+				// Bodies with increasing friction
+				const sphere_settings = SoftBodyCreator.CreateSphere();
+				const sphere_vertex = sphere_settings.mVertices;
+				for (let i=0; i< sphere_vertex.size(); i++)
+					sphere_vertex.at(i).mVelocity.z = 10;
+
+				const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
+				sphere.mPressure = 2000.0;
+
+				for (let i = 0; i <= 10; ++i)
+				{
+					sphere.mPosition.Set(-40.0 + i * 8.0, 1.0, 0);
+					sphere.mFriction = 0.1 * i;
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, 0x333333 + (i << 20) + ((10-i)<<12))
+				}
+
+				const cube_settings = SoftBodyCreator.CreateCube();
+				const cube_vertex = cube_settings.mVertices;
+				for (let i=0; i< cube_vertex.size(); i++)
+				cube_vertex.at(i).mVelocity.z = 10;
+				const cube = new Jolt.SoftBodyCreationSettings(cube_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
+
+				for (let i = 0; i <= 10; ++i)
+				{
+					cube.mPosition.Set(-40.0 + i * 8.0, 1.0, -5.0);
+					cube.mFriction = 0.1 * i;
+					const body = bodyInterface.CreateSoftBody(cube);
+					addToScene(body, 0x333333 + (i << 4)+ ((10-i)<<20))
+				}
+
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_friction.html
+++ b/Examples/soft/soft_friction.html
@@ -32,32 +32,30 @@
 				// Bodies with increasing friction
 				const sphere_settings = SoftBodyCreator.CreateSphere();
 				const sphere_vertex = sphere_settings.mVertices;
-				for (let i=0; i< sphere_vertex.size(); i++)
+				for (let i = 0; i < sphere_vertex.size(); i++)
 					sphere_vertex.at(i).mVelocity.z = 10;
 
 				const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
 				sphere.mPressure = 2000.0;
 
-				for (let i = 0; i <= 10; ++i)
-				{
+				for (let i = 0; i <= 10; ++i) {
 					sphere.mPosition.Set(-40.0 + i * 8.0, 1.0, 0);
 					sphere.mFriction = 0.1 * i;
 					const body = bodyInterface.CreateSoftBody(sphere);
-					addToScene(body, 0x333333 + (i << 20) + ((10-i)<<12))
+					addToScene(body, 0x333333 + (i << 20) + ((10 - i) << 12))
 				}
 
 				const cube_settings = SoftBodyCreator.CreateCube();
 				const cube_vertex = cube_settings.mVertices;
-				for (let i=0; i< cube_vertex.size(); i++)
-				cube_vertex.at(i).mVelocity.z = 10;
+				for (let i = 0; i < cube_vertex.size(); i++)
+					cube_vertex.at(i).mVelocity.z = 10;
 				const cube = new Jolt.SoftBodyCreationSettings(cube_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
 
-				for (let i = 0; i <= 10; ++i)
-				{
+				for (let i = 0; i <= 10; ++i) {
 					cube.mPosition.Set(-40.0 + i * 8.0, 1.0, -5.0);
 					cube.mFriction = 0.1 * i;
 					const body = bodyInterface.CreateSoftBody(cube);
-					addToScene(body, 0x333333 + (i << 4)+ ((10-i)<<20))
+					addToScene(body, 0x333333 + (i << 4) + ((10 - i) << 20))
 				}
 
 			});

--- a/Examples/soft/soft_gravity.html
+++ b/Examples/soft/soft_gravity.html
@@ -27,28 +27,27 @@
 
 				const floor = createFloor();
 				camera.position.z += 40;
+
 				// Bodies with increasing friction
 				const sphere_settings = SoftBodyCreator.CreateSphere();
 				const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
 				sphere.mPressure = 2000.0;
 
-				for (let i = 0; i <= 10; ++i)
-				{
+				for (let i = 0; i <= 10; ++i) {
 					sphere.mPosition.Set(-40.0 + i * 8.0, 10.0, 0);
 					sphere.mGravityFactor = 0.1 * i;
 					const body = bodyInterface.CreateSoftBody(sphere);
-					addToScene(body, 0x333333 + (i << 20) + ((10-i)<<12))
+					addToScene(body, 0x333333 + (i << 20) + ((10 - i) << 12))
 				}
 
 				const cube_settings = SoftBodyCreator.CreateCube();
 				const cube = new Jolt.SoftBodyCreationSettings(cube_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
 
-				for (let i = 0; i <= 10; ++i)
-				{
+				for (let i = 0; i <= 10; ++i) {
 					cube.mPosition.Set(-40.0 + i * 8.0, 10.0, -5.0);
 					cube.mGravityFactor = 0.1 * i;
 					const body = bodyInterface.CreateSoftBody(cube);
-					addToScene(body, 0x333333 + (i << 4)+ ((10-i)<<20))
+					addToScene(body, 0x333333 + (i << 4) + ((10 - i) << 20))
 				}
 
 			});

--- a/Examples/soft/soft_gravity.html
+++ b/Examples/soft/soft_gravity.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft Body Gravity Factor<br /> Gravity increases, Left to Right</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+
+				const floor = createFloor();
+				camera.position.z += 40;
+				// Bodies with increasing friction
+				const sphere_settings = SoftBodyCreator.CreateSphere();
+				const sphere = new Jolt.SoftBodyCreationSettings(sphere_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
+				sphere.mPressure = 2000.0;
+
+				for (let i = 0; i <= 10; ++i)
+				{
+					sphere.mPosition.Set(-40.0 + i * 8.0, 10.0, 0);
+					sphere.mGravityFactor = 0.1 * i;
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, 0x333333 + (i << 20) + ((10-i)<<12))
+				}
+
+				const cube_settings = SoftBodyCreator.CreateCube();
+				const cube = new Jolt.SoftBodyCreationSettings(cube_settings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
+
+				for (let i = 0; i <= 10; ++i)
+				{
+					cube.mPosition.Set(-40.0 + i * 8.0, 10.0, -5.0);
+					cube.mGravityFactor = 0.1 * i;
+					const body = bodyInterface.CreateSoftBody(cube);
+					addToScene(body, 0x333333 + (i << 4)+ ((10-i)<<20))
+				}
+
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_lra_constraint.html
+++ b/Examples/soft/soft_lra_constraint.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<div id="container">Loading...</div>
-		<div id="info">JoltPhysics.js Soft LRA Constraint<br /> Red: LRA Type None<br/> Green: LRA Type Euclidean Distance</div>
+		<div id="info">JoltPhysics.js Soft LRA Constraint<br /> Red: LRA Type None<br /> Green: LRA Type Euclidean Distance</div>
 
 		<script src="../js/three/three.min.js"></script>
 		<script src="../js/three/OrbitControls.js"></script>
@@ -18,13 +18,13 @@
 		<script src="../js/soft-body-creator.js"></script>
 
 		<script type="module">
-			
+
 			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
 			import initJolt from '../js/jolt-physics.wasm-compat.js';
 
 			const cNumVerticesX = 10;
-			const	cNumVerticesZ = 50;
-			const	cVertexSpacing = 0.5;
+			const cNumVerticesZ = 50;
+			const cVertexSpacing = 0.5;
 
 			initJolt().then(async function (Jolt) {
 				// Initialize this example
@@ -32,12 +32,12 @@
 
 				createFloor();
 				camera.position.z += 40;
-				const inv_mass = (x, z) => z == 0 ? 0: 1;
+				const inv_mass = (x, z) => z == 0 ? 0 : 1;
 				const perturbation = (_x, inZ) => ({
-						x: 0,
-						y: 0,
-						z: 0
-					});
+					x: 0,
+					y: 0,
+					z: 0
+				});
 
 				const rotation = Jolt.Quat.prototype.sIdentity();
 				const position = new Jolt.RVec3();

--- a/Examples/soft/soft_lra_constraint.html
+++ b/Examples/soft/soft_lra_constraint.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft LRA Constraint<br /> Red: LRA Type None<br/> Green: LRA Type Euclidean Distance</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+
+			const cNumVerticesX = 10;
+			const	cNumVerticesZ = 50;
+			const	cVertexSpacing = 0.5;
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+
+				createFloor();
+				camera.position.z += 40;
+				const inv_mass = (x, z) => z == 0 ? 0: 1;
+				const perturbation = (_x, inZ) => ({
+						x: 0,
+						y: 0,
+						z: 0
+					});
+
+				const rotation = Jolt.Quat.prototype.sIdentity();
+				const position = new Jolt.RVec3();
+
+				const va = new Jolt.SoftBodySharedSettingsVertexAttributes();
+				va.mShearCompliance = va.mCompliance = 1.0e-3; // Soften the edges a bit so that the effect of the LRA constraints is more visible
+
+				const COLOR_NONE = 0xaa0000;
+				const COLOR_EUCLID_DISTANCE = 0x00aa00;
+
+				{
+					// Cloth with distance bend constraints
+					va.mLRAType = Jolt.SoftBodySharedSettings_ELRAType_None;
+					const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation, Jolt.SoftBodySharedSettings_EBendType_None, va);
+					position.Set(-10, 25, 0);
+					const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(cloth);
+					addToScene(body, COLOR_NONE);
+				}
+
+				{
+					// Cloth with dihedral bend constraints
+					va.mLRAType = Jolt.SoftBodySharedSettings_ELRAType_EuclideanDistance;
+					const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation, Jolt.SoftBodySharedSettings_EBendType_None, va);
+					position.Set(10, 25, 0);
+					const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+					const body = bodyInterface.CreateSoftBody(cloth);
+					addToScene(body, COLOR_EUCLID_DISTANCE);
+				}
+
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_sphere_pressure.html
+++ b/Examples/soft/soft_sphere_pressure.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>JoltPhysics.js demo</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link rel="stylesheet" type="text/css" href="../style.css">
+	</head>
+	<body>
+		<div id="container">Loading...</div>
+		<div id="info">JoltPhysics.js Soft Body - Sphere Pressure<br /> Pressure increases, Left to Right</div>
+
+		<script src="../js/three/three.min.js"></script>
+		<script src="../js/three/OrbitControls.js"></script>
+		<script src="../js/three/WebGL.js"></script>
+		<script src="../js/three/stats.min.js"></script>
+		<script src="../js/example.js"></script>
+		<script src="../js/soft-body-creator.js"></script>
+
+		<script type="module">
+			// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+			import initJolt from '../js/jolt-physics.wasm-compat.js';
+
+			initJolt().then(async function (Jolt) {
+				// Initialize this example
+				initExample(Jolt, null);
+
+				createFloor();
+
+				camera.position.z += 40;
+
+
+				// Bodies with increasing pressure
+				const sphereSettings = SoftBodyCreator.CreateSphere(2.0);
+				const sphere = new Jolt.SoftBodyCreationSettings(sphereSettings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
+
+				for (let i = 0; i <= 10; ++i)
+				{
+					sphere.mPosition.Set(-40 + i * 8, 10, 0);
+					sphere.mPressure = 1000.0 * i;
+					sphere.mUpdatePosition = false;
+					const body = bodyInterface.CreateSoftBody(sphere);
+					addToScene(body, (25* i) | 0x00aa00 | (((10-i)*25)<<16));
+				}
+
+			});
+		</script>
+	</body>
+</html>

--- a/Examples/soft/soft_sphere_pressure.html
+++ b/Examples/soft/soft_sphere_pressure.html
@@ -34,13 +34,12 @@
 				const sphereSettings = SoftBodyCreator.CreateSphere(2.0);
 				const sphere = new Jolt.SoftBodyCreationSettings(sphereSettings, Jolt.RVec3.prototype.sZero(), Jolt.Quat.prototype.sIdentity(), LAYER_MOVING);
 
-				for (let i = 0; i <= 10; ++i)
-				{
+				for (let i = 0; i <= 10; ++i) {
 					sphere.mPosition.Set(-40 + i * 8, 10, 0);
 					sphere.mPressure = 1000.0 * i;
 					sphere.mUpdatePosition = false;
 					const body = bodyInterface.CreateSoftBody(sphere);
-					addToScene(body, (25* i) | 0x00aa00 | (((10-i)*25)<<16));
+					addToScene(body, (25 * i) | 0x00aa00 | (((10 - i) * 25) << 16));
 				}
 
 			});

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -304,6 +304,12 @@ constexpr SoftBodySharedSettings_EBendType SoftBodySharedSettings_EBendType_None
 constexpr SoftBodySharedSettings_EBendType SoftBodySharedSettings_EBendType_Distance = SoftBodySharedSettings::EBendType::Distance;
 constexpr SoftBodySharedSettings_EBendType SoftBodySharedSettings_EBendType_Dihedral = SoftBodySharedSettings::EBendType::Dihedral;
 
+// Alias for ELRAType values to avoid clashes
+using SoftBodySharedSettings_ELRAType = SoftBodySharedSettings::ELRAType;
+constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_None = SoftBodySharedSettings::ELRAType::None;
+constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_EuclideanDistance = SoftBodySharedSettings::ELRAType::EuclideanDistance;
+constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_GeodesicDistance = SoftBodySharedSettings::ELRAType::GeodesicDistance;
+
 // Callback for traces
 static void TraceImpl(const char *inFMT, ...)
 { 

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -310,6 +310,15 @@ constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_None =
 constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_EuclideanDistance = SoftBodySharedSettings::ELRAType::EuclideanDistance;
 constexpr SoftBodySharedSettings_ELRAType SoftBodySharedSettings_ELRAType_GeodesicDistance = SoftBodySharedSettings::ELRAType::GeodesicDistance;
 
+// Helper class to store information about the memory layout of SoftBodyVertex
+class SoftBodyVertexTraits
+{
+public:
+	static constexpr uint mPreviousPositionOffset = offsetof(SoftBodyVertex, mPreviousPosition);
+	static constexpr uint mPositionOffset = offsetof(SoftBodyVertex, mPosition);
+	static constexpr uint mVelocityOffset = offsetof(SoftBodyVertex, mVelocity);
+};
+
 // Callback for traces
 static void TraceImpl(const char *inFMT, ...)
 { 

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -2562,6 +2562,12 @@ interface SoftBodyVertex {
 	attribute float mInvMass;
 };
 
+interface SoftBodyVertexTraits {
+	static readonly attribute unsigned long mPreviousPositionOffset;
+	static readonly attribute unsigned long mPositionOffset;
+	static readonly attribute unsigned long mVelocityOffset;
+};
+
 interface ArraySoftBodyVertex {
 	boolean empty();
 	long size();

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -210,6 +210,12 @@ enum SoftBodySharedSettings_EBendType {
 	"SoftBodySharedSettings_EBendType_Dihedral"
 };
 
+enum SoftBodySharedSettings_ELRAType {
+ "SoftBodySharedSettings_ELRAType_None",
+ "SoftBodySharedSettings_ELRAType_EuclideanDistance",
+ "SoftBodySharedSettings_ELRAType_GeodesicDistance"
+};
+
 interface Vec3MemRef {
 };
 
@@ -2487,6 +2493,8 @@ interface SoftBodySharedSettingsVertexAttributes {
 	attribute float mCompliance;
 	attribute float mShearCompliance;
 	attribute float mBendCompliance;
+	attribute SoftBodySharedSettings_ELRAType mLRAType;
+	attribute float mLRAMaxDistanceMultiplier;
 };
 
 interface ArraySoftBodySharedSettingsVertexAttributes {

--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -211,9 +211,9 @@ enum SoftBodySharedSettings_EBendType {
 };
 
 enum SoftBodySharedSettings_ELRAType {
- "SoftBodySharedSettings_ELRAType_None",
- "SoftBodySharedSettings_ELRAType_EuclideanDistance",
- "SoftBodySharedSettings_ELRAType_GeodesicDistance"
+	"SoftBodySharedSettings_ELRAType_None",
+	"SoftBodySharedSettings_ELRAType_EuclideanDistance",
+	"SoftBodySharedSettings_ELRAType_GeodesicDistance"
 };
 
 interface Vec3MemRef {
@@ -916,8 +916,8 @@ interface RotatedTranslatedShapeSettings {
 RotatedTranslatedShapeSettings implements DecoratedShapeSettings;
 
 interface RotatedTranslatedShape {
-	[Value] Quat GetRotation();	
-	[Value] Vec3 GetPosition();	
+	[Value] Quat GetRotation();
+	[Value] Vec3 GetPosition();
 };
 
 RotatedTranslatedShape implements DecoratedShape;
@@ -1344,7 +1344,7 @@ SixDOFConstraint implements TwoBodyConstraint;
 
 interface PathConstraintSettings {
 	void PathConstraintSettings();
-	
+
 	[Const] attribute PathConstraintPath mPath;
 	[Value] attribute Vec3 mPathPosition;
 	[Value] attribute Quat mPathRotation;
@@ -1396,7 +1396,7 @@ PathConstraint implements TwoBodyConstraint;
 
 interface PulleyConstraintSettings {
 	void PulleyConstraintSettings();
-	
+
 	attribute EConstraintSpace mSpace;
 	[Value] attribute RVec3 mBodyPoint1;
 	[Value] attribute RVec3 mFixedPoint1;
@@ -1413,7 +1413,7 @@ interface PulleyConstraint {
 	void SetLength(float inMinLength, float inMaxLength);
 	float GetMinLength();
 	float GetMaxLength();
-	float GetCurrentLength();	
+	float GetCurrentLength();
 };
 
 PulleyConstraint implements TwoBodyConstraint;
@@ -1421,7 +1421,7 @@ PulleyConstraint implements TwoBodyConstraint;
 interface GearConstraintSettings {
 	void GearConstraintSettings();
 	void SetRatio(long inNumTeethGear1, long inNumTeethGear2);
-	
+
 	attribute EConstraintSpace mSpace;
 	[Value] attribute Vec3 mHingeAxis1;
 	[Value] attribute Vec3 mHingeAxis2;
@@ -1440,7 +1440,7 @@ GearConstraint implements TwoBodyConstraint;
 interface RackAndPinionConstraintSettings {
 	void RackAndPinionConstraintSettings();
 	void SetRatio(long inNumTeethRack, float inRackLength, long inNumTeethPinion);
-	
+
 	attribute EConstraintSpace mSpace;
 	[Value] attribute Vec3 mHingeAxis;
 	[Value] attribute Vec3 mSliderAxis;
@@ -2399,7 +2399,7 @@ interface SoftBodySharedSettingsSkinned
 	attribute float mBackStopDistance;
 	attribute float mBackStopRadius;
 };
-	
+
 interface SoftBodySharedSettingsLRA {
 	void SoftBodySharedSettingsLRA(unsigned long inVertex1, unsigned long inVertex2, float inMaxDistance);
 
@@ -3249,14 +3249,14 @@ interface Skeleton {
 interface SkeletalAnimationJointState {
 	void FromMatrix([Const, Ref] Mat44 inMatrix);
 	[Value] Mat44 ToMatrix();
-	
+
 	[Value] attribute Vec3 mTranslation;
 	[Value] attribute Quat mRotation;
 };
 
 interface SkeletalAnimationKeyframe {
 	void SkeletalAnimationKeyframe();
-	
+
 	attribute float mTime;
 };
 
@@ -3275,7 +3275,7 @@ interface ArraySkeletonKeyframe {
 
 interface SkeletalAnimationAnimatedJoint {
 	void SkeletalAnimationAnimatedJoint();
-	
+
 	[Value] attribute JPHString mJointName;
 	[Value] attribute ArraySkeletonKeyframe mKeyframes;
 };
@@ -3354,7 +3354,7 @@ interface RagdollSettings {
 	void DisableParentChildCollisions([Const] optional Mat44MemRef inJointMatrices, optional float inMinSeparationDistance);
 	void CalculateBodyIndexToConstraintIndex();
 	void CalculateConstraintIndexToBodyIdxPair();
-	
+
 	attribute Skeleton mSkeleton;
 	[Value] attribute ArrayRagdollPart mParts;
 	[Value] attribute ArrayRagdollAdditionalConstraint mAdditionalConstraints;
@@ -3379,7 +3379,7 @@ interface Ragdoll {
 	void GetRootTransform([Ref] RVec3 outPosition, [Ref] Quat outRotation, optional boolean inLockBodies);
 	long GetBodyCount();
 	[Value] BodyID GetBodyID(long inBodyIndex);
-	[Const, Ref] BodyIDVector GetBodyIDs(); 
+	[Const, Ref] BodyIDVector GetBodyIDs();
 	long GetConstraintCount();
 	[Value] AABox GetWorldSpaceBounds(optional boolean inLockBodies);
 	[Const] TwoBodyConstraint GetConstraint(long inConstraintIndex);


### PR DESCRIPTION
This adds in some of the Jolt 5.0 LRA soft body constrain code, using SoftBodySharedSettings_ELRAType

One of the files is riskier, with the example.js saving direct mapping of the MotionProperties pointers to vertex location. **This example.js file could be reverted without impacting anything else.**
This was partly when I was trying to skin to other models, and also avoid rebuilding 16+ soft models via ShapeGetTriangles every frame. It is coded specifically to the SoftVertex CurrentPosition offset, based on PreviousPosition being before it and using 16 byte alignment, but should Jolt ever move the data location during runtime, or the build and class structure ever change, or any of this Soft Vertex usage of Vec3 ever change to RVec3, then this code would break or need to be updated. If WebIDL supported [Ref] attributes, this could at least be cleaner than hard-coded offsets into class structs. This file can be discarded if wanted.

The 5.0.0 SoftBodyCreator was ported in almost 1-to-1, with the only difference being `Cube` supporting compliance values in its factory, and `perturbation` does not return a Jolt memory bound Vec3 given manual memory management.

The remaining code is fairly 1-to-1 for the following JoltPhysics Samples:

* SoftBodyBendConstraintTest.cpp
* SoftBodyFrictionTest.cpp
* SoftBodyGravityFactorTest.cpp
* SoftBodyLRAConstraintTest.cpp
* SoftBodyPressureTest.cpp

+ Demo of Cube volume, although there is not easily a way to show the range of impact of Compliance in an X/Y chart without having one or two entries fly away. It is also hard to get good jelly colors (vibrant and transparent), so the demo can always be changed to just use regular solid colors with no transparent shaders.

Some of the demos seem a little redundant like Gravity and Friction, although it does show how soft bodies act different than rigid in those case like pressure having more impact in low-grav, or how a soft-sphere rolls by spilling over itself.