### PR TITLE
Debug Renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ set(EMCC_ARGS
   -s TOTAL_STACK=1048576
   -s TOTAL_MEMORY=${TOTAL_MEMORY}
   ${MEMORY_PROFILER_FLAG}
-	${DEBUG_RENDER_FLAG}
   ${INCLUDE_DEMANGLE_ALL_FLAG}
   ${ENABLE_SIMD_FLAG})
 
@@ -150,7 +149,6 @@ set(EMCC_GLUE_ARGS
   -DJPH_DISABLE_CUSTOM_ALLOCATOR
   -include ${JOLT_HEADER_FILE}
   ${MEMORY_PROFILER_FLAG}
-	${DEBUG_RENDER_FLAG}
   ${ENABLE_SIMD_FLAG})
 
 # Can't find a way to automatically inherit settings set by target_compile_definitions, so hardcoding defines here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(JOLT_FRONT_MATTER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/front-matter.js)
 set(JOLT_HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/JoltJS.h)
 set(JOLT_IDL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/JoltJS.idl)
 set(OUTPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/dist/)
+set(JOLT_TYPING ${OUTPUT_FOLDER}/types.d.ts)
 
 # Option to turn on memory profiling
 option(ENABLE_MEMORY_PROFILER "Enable emscriptens memory profiler to help find leaks" OFF)
@@ -110,6 +111,7 @@ set(EMCC_ARGS
   -s TOTAL_STACK=1048576
   -s TOTAL_MEMORY=${TOTAL_MEMORY}
   ${MEMORY_PROFILER_FLAG}
+	${DEBUG_RENDER_FLAG}
   ${INCLUDE_DEMANGLE_ALL_FLAG}
   ${ENABLE_SIMD_FLAG})
 
@@ -148,14 +150,17 @@ set(EMCC_GLUE_ARGS
   -DJPH_DISABLE_CUSTOM_ALLOCATOR
   -include ${JOLT_HEADER_FILE}
   ${MEMORY_PROFILER_FLAG}
+	${DEBUG_RENDER_FLAG}
   ${ENABLE_SIMD_FLAG})
 
 # Can't find a way to automatically inherit settings set by target_compile_definitions, so hardcoding defines here
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+	set(JOLT_IDL_FILE ${JOLT_IDL_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/JoltJS-DebugRenderer.idl )
 	set(EMCC_GLUE_ARGS
 		${EMCC_GLUE_ARGS}
 		-DJPH_DEBUG_RENDERER -DJPH_PROFILE_ENABLED -D_DEBUG)
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+	set(JOLT_IDL_FILE ${JOLT_IDL_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/JoltJS-DebugRenderer.idl )
 	set(EMCC_GLUE_ARGS
 		${EMCC_GLUE_ARGS}
 		-DJPH_DEBUG_RENDERER -DJPH_PROFILE_ENABLED -DNDEBUG)
@@ -175,9 +180,17 @@ endif()
 project("JoltPhysics.js")
 
 add_custom_command(
-	OUTPUT glue.cpp glue.js
+	OUTPUT ${JOLT_TYPING}
+	COMMAND npx webidl-dts-gen -e -d -i jolt.idl -o ${JOLT_TYPING} -n Jolt
+	DEPENDS jolt.idl
+	COMMENT "Generating JoltPhysics.js bindings"
+	VERBATIM)
+
+add_custom_command(
+	OUTPUT glue.cpp glue.js jolt.idl
 	BYPRODUCTS parser.out WebIDLGrammar.pkl
-	COMMAND ${PYTHON} ${WEBIDL_BINDER_SCRIPT} ${JOLT_IDL_FILE} glue
+	COMMAND cat ${JOLT_IDL_FILE} > jolt.idl
+	COMMAND ${PYTHON} ${WEBIDL_BINDER_SCRIPT} jolt.idl glue
 	DEPENDS ${JOLT_IDL_FILE}
 	COMMENT "Generating JoltPhysics.js bindings"
 	VERBATIM)
@@ -188,7 +201,7 @@ add_custom_command(
 	DEPENDS glue.cpp ${JOLT_HEADER_FILE}
 	COMMENT "Building JoltPhysics.js bindings"
 	VERBATIM)
-add_custom_target(jolt-bindings ALL DEPENDS glue.js glue.o)
+add_custom_target(jolt-bindings ALL DEPENDS glue.js glue.o ${JOLT_TYPING})
 
 if (NOT BUILD_WASM_COMPAT_ONLY)
 	if (NOT ENABLE_MULTI_THREADING # Not compatible with multi threading due to error: 'void wasm::I64ToI32Lowering::visitStore(Store *): Assertion `!curr->isAtomic && "atomic store not implemented"' failed.'

--- a/Examples/index.html
+++ b/Examples/index.html
@@ -39,6 +39,7 @@
 			<li><a href="ray_cast.html">Ray Cast Demo</a> - Shows how to do a ray cast</li>
 			<li><a href="alternative_collision_filtering.html">Alternative Collision Filtering Demo</a> - Shows how to use a group bit field and a filter bit mask to do collision filtering</li>
 			<li><a href="proper_cleanup.html">Proper Cleanup Demo</a> - Shows how to clean up memory</li>
+			<li><a href="render-debug.html">Debug Rendering Demo</a> - Shows how to draw the state of the physics system. Note that this will not show anything in the default Distribution build, you'll need to build a Debug or Release build yourself.</li>
 		</ul>
 	</body>
 </html>

--- a/Examples/js/debug-renderer.js
+++ b/Examples/js/debug-renderer.js
@@ -1,0 +1,358 @@
+const unwrapV3 = (ptr) => wrapVec3(Jolt.wrapPointer(ptr, Jolt.RVec3));
+const textDecoder = new TextDecoder();
+class DebugRenderer {
+	materialCache = {};
+	lineCache = {};
+	lineMesh = {};
+	triangleCache = {};
+	triangleMesh = {};
+	meshList = [];
+	geometryList = [];
+	geometryCache = [];
+	textCache = [];
+	textList = [];
+	renderer;
+	css3dRender;
+	constructor() {
+		const renderer = this.renderer = new Jolt.DebugRendererJS();
+		renderer.DrawLine = this.drawLine.bind(this);
+		renderer.DrawTriangle = this.drawTriangle.bind(this);
+		renderer.DrawText3D = this.drawText3D.bind(this);
+		renderer.DrawGeometryWithID = this.drawGeometryWithID.bind(this);
+		renderer.CreateTriangleBatchID = this.createTriangleBatchID.bind(this);
+		renderer.CreateTriangleBatchIDWithIndex = this.createTriangleBatchIDWithIndex.bind(this);
+	}
+	initialized = false;
+	Initialize() {
+		if (!this.initialized) {
+			this.renderer.Initialize();
+			this.initialized = true;
+		}
+	}
+    // Draws all bodies, assuming DrawSettings has mDrawShape enabled
+	DrawBodies(system, inDrawSettings) {
+		this.renderer.DrawBodies(system, inDrawSettings);
+	}
+    // Draws constraint relationships as lines. Some constraints include additional Text Data
+	DrawConstraints(system) {
+		this.renderer.DrawConstraints(system);
+	}
+    // Draws text indicating limits on constraints, such as the distance of a distance constraint
+	DrawConstraintLimits(system) {
+		this.renderer.DrawConstraintLimits(system);
+	}
+
+	drawLine(inFrom, inTo, inColor) {
+		const colorU32 = Jolt.wrapPointer(inColor, Jolt.Color).mU32 >>> 0;
+		const arr = this.lineCache[colorU32] = this.lineCache[colorU32] || [];
+		const v0 = unwrapV3(inFrom);
+		const v1 = unwrapV3(inTo);
+		arr.push(v0, v1);
+	}
+	drawTriangle(inV1, inV2, inV3, inColor, inCastShadow) {
+		const colorU32 = Jolt.wrapPointer(inColor, Jolt.Color).mU32 >>> 0;
+		const arr = this.lineCache[colorU32] = this.lineCache[colorU32] || [];
+		const v0 = unwrapV3(inV1);
+		const v1 = unwrapV3(inV2);
+		const v2 = unwrapV3(inV3);
+		arr.push(v0, v1);
+		arr.push(v1, v2);
+		arr.push(v2, v0);
+	}
+	drawText3D(inPosition, inStringPtr, inStringLen, inColor, inHeight) {
+		const color = Jolt.wrapPointer(inColor, Jolt.Color).mU32 >>> 0;
+		const position = unwrapV3(inPosition);
+		const height = inHeight;
+		const text = textDecoder.decode(Jolt.HEAPU8.subarray(inStringPtr, inStringPtr + inStringLen));
+		this.textList.push({ color, position, height, text });
+	}
+    // Assuming a Render Geometry/Batch has been created, the following is a request to render the Geometry at a given model location
+	drawGeometryWithID(inModelMatrix, inWorldSpaceBounds, inLODScaleSq, inModelColor, inGeometryID, inCullMode, inCastShadow, inDrawMode) {
+		const colorU32 = Jolt.wrapPointer(inModelColor, Jolt.Color).mU32 >>> 0;
+		const modelMatrix = Jolt.wrapPointer(inModelMatrix, Jolt.RMat44);
+		const v0 = wrapVec3(modelMatrix.GetAxisX());
+		const v1 = wrapVec3(modelMatrix.GetAxisY());
+		const v2 = wrapVec3(modelMatrix.GetAxisZ());
+		const v3 = wrapVec3(modelMatrix.GetTranslation());
+		const matrix = new THREE.Matrix4().makeBasis(v0, v1, v2).setPosition(v3);
+		this.geometryList.push({ matrix: matrix, geometry: this.geometryCache[inGeometryID], color: colorU32, drawMode: inDrawMode, cullMode: inCullMode });
+	}
+    // On initializing the Renderer, or adding new rigid Mesh, the following methods will send the vertex data here to construct a Render Geometry
+	createTriangleBatchID(inTriangles, inTriangleCount) {
+		const batchID = this.geometryCache.length;
+		const { mPositionOffset, mNormalOffset, mUVOffset, mSize } = Jolt.DebugRendererVertexTraits.prototype;
+		const interleaveBufferF32 = new Float32Array(inTriangleCount * 3 * mSize / 4);
+
+        // Assuming a triangle is tightly packed (always 3 vertex with no leading or trailing space), we can treat the data chunk
+        // as a whole as if it was an interleaved vertex buffer, assuming no alignment issues such that element N+1 is more than (size) from element N+0
+        // This case is always true as of this coding, but should it not be, the following [else] case will extract just the 3 vertex
+		if (Jolt.DebugRendererTriangleTraits.prototype.mVOffset === 0 && Jolt.DebugRendererTriangleTraits.prototype.mSize === mSize * 3) {
+			interleaveBufferF32.set(new Float32Array(Jolt.HEAPF32.buffer, inTriangles, interleaveBufferF32.length));
+		}
+		else {
+			const vertexChunk = mSize / 4 * 3;
+			for (let i = 0; i < inTriangleCount; i++) {
+				let triOffset = inTriangles + i * Jolt.DebugRendererTriangleTraits.prototype.mSize + Jolt.DebugRendererTriangleTraits.prototype.mVOffset;
+				interleaveBufferF32.set(new Float32Array(Jolt.HEAPF32.buffer, triOffset, i * vertexChunk));
+			}
+		}
+		// Create a three mesh
+		const geometry = new THREE.BufferGeometry();
+		const interleavedBuffer = new THREE.InterleavedBuffer(interleaveBufferF32, mSize / 4);
+		geometry.setAttribute('position', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, mPositionOffset / 4));
+		geometry.setAttribute('normal', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, mNormalOffset / 4));
+		geometry.setAttribute('uv', new THREE.InterleavedBufferAttribute(interleavedBuffer, 2, mUVOffset / 4));
+		this.geometryCache.push(geometry);
+		return batchID;
+	}
+	createTriangleBatchIDWithIndex(inVertices, inVertexCount, inIndices, inIndexCount) {
+		const batchID = this.geometryCache.length;
+		const { mPositionOffset, mNormalOffset, mUVOffset, mSize } = Jolt.DebugRendererVertexTraits.prototype;
+		const interleaveBufferF32 = new Float32Array(inVertexCount * mSize / 4);
+		interleaveBufferF32.set(new Float32Array(Jolt.HEAPF32.buffer, inVertices, interleaveBufferF32.length));
+		const index = new Uint32Array(inIndexCount);
+
+        // Unlike triangles, by definition this data will be an interleaved data buffer
+		index.set(Jolt.HEAPU32.subarray(inIndices / 4, inIndices / 4 + inIndexCount));
+		// Create a three mesh
+		const geometry = new THREE.BufferGeometry();
+		const interleavedBuffer = new THREE.InterleavedBuffer(interleaveBufferF32, mSize / 4);
+		geometry.setAttribute('position', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, mPositionOffset / 4));
+		geometry.setAttribute('normal', new THREE.InterleavedBufferAttribute(interleavedBuffer, 3, mNormalOffset / 4));
+		geometry.setAttribute('uv', new THREE.InterleavedBufferAttribute(interleavedBuffer, 2, mUVOffset / 4));
+		geometry.setIndex(new THREE.BufferAttribute(index, 1));
+		this.geometryCache.push(geometry);
+		return batchID;
+	}
+    // Debug Renderer supports applying color, Front and Back face culling, and drawing as solid or wire frame.
+    // These all correspond to different Three Materials, so cache them here.
+	getMeshMaterial(color, cullMode, drawMode) {
+		const key = `${color}|${cullMode}|${drawMode}`;
+		if (!this.materialCache[key]) {
+			const material = this.materialCache[key] = new THREE.MeshPhongMaterial({ color: color });
+			if (drawMode == Jolt.EDrawMode_Wireframe) {
+				material.wireframe = true;
+			}
+			if (cullMode !== undefined) {
+				switch (cullMode) {
+					case Jolt.ECullMode_Off:
+						material.side = THREE.DoubleSide;
+						break;
+					case Jolt.ECullMode_CullBackFace:
+						material.side = THREE.FrontSide;
+						break;
+					case Jolt.ECullMode_CullFrontFace:
+						material.side = THREE.BackSide;
+						break;
+				}
+			}
+		}
+		return this.materialCache[key];
+	}
+    // The following call flushes all accumulated Draw calls to new or existing Meshes that have been cached.
+    // Line/Triangle calls are combined into single Meshes per material.
+    // Text3D calls trigger a lazy initialization of CSS3D Render to render the text as transformed DIVs
+	Render() {
+        // Clear previous frames meshes, in case this frame no longer has these meshes.
+		[Object.values(this.lineMesh), Object.values(this.triangleMesh), this.meshList, this.textCache].forEach(meshes => {
+			meshes.forEach(mesh => mesh.visible = false);
+		});
+		Object.entries(this.lineCache).forEach(([colorU32, points]) => {
+			const color = parseInt(colorU32, 10);
+			if (this.lineMesh[color]) {
+				this.lineMesh[color].geometry = new THREE.BufferGeometry().setFromPoints(points);
+				const mesh = this.lineMesh[color];
+				mesh.visible = true;
+			}
+			else {
+				const material = new THREE.LineBasicMaterial({ color: color });
+				const geometry = new THREE.BufferGeometry().setFromPoints(points);
+				const mesh = this.lineMesh[color] = new THREE.LineSegments(geometry, material);
+				mesh.layers.set(1);
+				scene.add(mesh);
+			}
+		});
+		Object.entries(this.triangleCache).forEach(([colorU32, points]) => {
+			const color = parseInt(colorU32, 10);
+			if (this.triangleMesh[color]) {
+				this.triangleMesh[color].geometry = new THREE.BufferGeometry().setFromPoints(points);
+				const mesh = this.triangleMesh[color];
+				mesh.visible = true;
+			}
+			else {
+				const material = this.getMeshMaterial(color, undefined, undefined);
+				const geometry = new THREE.BufferGeometry().setFromPoints(points);
+				const mesh = this.triangleMesh[color] = new THREE.Mesh(geometry, material);
+				mesh.layers.set(1);
+				scene.add(mesh);
+			}
+		});
+		this.geometryList.forEach(({ geometry, color, matrix, cullMode, drawMode }, i) => {
+			const material = this.getMeshMaterial(color, cullMode, drawMode);
+			let mesh = this.meshList[i];
+			if (!mesh) {
+				mesh = this.meshList[i] = new THREE.Mesh(geometry, material);
+				mesh.layers.set(1);
+				scene.add(mesh);
+			}
+			else {
+				mesh.material = material;
+				mesh.geometry = geometry;
+			}
+			matrix.decompose(mesh.position, mesh.quaternion, mesh.scale);
+			mesh.visible = true;
+		});
+		this.textList.forEach(({ position, text, color, height }, i) => {
+			let mesh = this.textCache[i];
+			if (!this.css3dRender) {
+                // Lazy construct a CSS3D Renderer.
+				this.css3dRender = new THREE.CSS3DRenderer();
+				const renderSize = new THREE.Vector2();
+				renderer.getSize(renderSize);
+				this.css3dRender.setSize(renderSize.x, renderSize.y);
+				const element = this.css3dRender.domElement;
+				element.style.position = 'absolute';
+				element.style.left = element.style.right = element.style.top = element.style.bottom = '0';
+				document.getElementById('container')?.append(element);
+                window.addEventListener('resize', () => { renderer.getSize(renderSize); this.css3dRender.setSize(renderSize.x, renderSize.y);}, false);
+			}
+			if (!mesh) {
+				mesh = this.textCache[i] = new THREE.CSS3DObject(document.createElement('div'));
+				mesh.element.style.display = 'block';
+				mesh.element.style.fontSize = '1px';
+				mesh.layers.set(1);
+				scene.add(mesh);
+			}
+			else {
+				mesh.element.innerText = text;
+				mesh.element.style.color = '#' + ('000000' + color.toString(16)).substr(-6);
+			}
+			mesh.position.copy(position);
+			mesh.visible = true;
+		});
+        // Render the CSS 3D here (updates the DIV locations and css transforms)
+		this.css3dRender && this.css3dRender.render(scene, camera);
+        // Clear the accumulators of [Draw] requests
+		this.geometryList = [];
+		this.textList = [];
+		this.lineCache = {};
+		this.triangleCache = {};
+	}
+}
+
+// The following is a non-exhaustive list of options that may be provided to the DebugRender's DrawBodies call
+const BodyDrawSettingsMap = [
+	{ key: 'mDrawShape', label: 'Shape' },
+	{ key: 'mDrawShapeWireframe', label: 'Shape Wireframe' },
+	{ key: 'mDrawShapeColor', label: 'Shape Color', options: [
+			{ key: "EShapeColor_InstanceColor", label: 'Instance Color' },
+			{ key: "EShapeColor_ShapeTypeColor", label: 'Shape Type Color' },
+			{ key: "EShapeColor_MotionTypeColor", label: 'Motion Color' },
+			{ key: "EShapeColor_SleepColor", label: 'Sleep Color' },
+			{ key: "EShapeColor_IslandColor", label: 'Island Color' },
+			{ key: "EShapeColor_MaterialColor", label: 'Material Color' }
+		] },
+	{ key: 'mDrawBoundingBox', label: 'Bounding Box' },
+	{ key: 'mDrawCenterOfMassTransform', label: 'Center of Mass Transform' },
+	{ key: 'mDrawWorldTransform', label: 'World Transform' },
+	{ key: 'mDrawVelocity', label: 'Velocity' },
+	{ key: 'mDrawMassAndInertia', label: 'Mass And Inertia' },
+	{ key: 'mDrawSleepStats', label: 'Sleep Stats' },
+	{ header: 'Soft Body' },
+	{ key: 'mDrawSoftBodyVertices', label: 'Vertices' },
+	{ key: 'mDrawSoftBodyVertexVelocities', label: 'Vertex Velocities' },
+	{ key: 'mDrawSoftBodyEdgeConstraints', label: 'Edge Constraints' },
+	{ key: 'mDrawSoftBodyBendConstraints', label: 'Bend Constraints' },
+	{ key: 'mDrawSoftBodyVolumeConstraints', label: 'Volume Constraints' },
+	{ key: 'mDrawSoftBodySkinConstraints', label: 'Skin Constraints' },
+	{ key: 'mDrawSoftBodyLRAConstraints', label: 'LRA Constraints' }
+];
+
+
+class RenderWidget {
+	renderer;
+	bodyDrawSettings;
+	domElement;
+	drawConstraints = true;
+	drawBodies = true;
+	constructor(jolt) {
+		window.Jolt = jolt;
+		this.renderer = new DebugRenderer();
+		this.bodyDrawSettings = new Jolt.BodyManagerDrawSettings();
+		this.domElement = document.createElement('div');
+		this.domElement.className = "debug-renderer collapsed";
+		this.domElement.innerHTML = `
+	<style>
+	.debug-renderer { z-index: 2; position: absolute; right: 0; top: 120px; max-width: 300px; background: rgba(0,0,0,.8);color: white; padding: 5px; border: 2px solid white; border-radius: 8px; }
+	.debug-renderer label { display: block }
+	.debug-renderer > b { display: block; padding: 5px; text-align: center; }
+	.debug-renderer.collapsed label, .debug-renderer.collapsed h4, .debug-renderer.collapsed select { display: none}
+	.debug-render option { font-size: 16px }
+	</style>
+	<b>Debug Menu <button>SHOW</button></b>`
+		let collapsed = true;
+		const button = this.domElement.querySelector('button');
+		button.onclick = () => { this.domElement.classList.toggle('collapsed'); collapsed = !collapsed; button.innerText = collapsed ? 'SHOW' : 'HIDE'; };
+	}
+	init() {
+		const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+		dirLight.position.set(10, 10, 5);
+		dirLight.layers.set(1);
+		scene.add(dirLight);
+		scene.layers.mask = 3;
+		const renderMask = document.createElement('select');
+		renderMask.innerHTML = `<option value='1' selected>ORIGINAL</option><option value='2'>DEBUG</option><option value='3'>BOTH</option>`;
+		renderMask.onchange = () => camera.layers.mask = parseInt(renderMask.value, 10);
+		this.domElement.append(renderMask);
+	  this.addCheckBox('Draw Bodies', this.drawBodies, (checked) => this.drawBodies = checked);
+		this.addCheckBox('Draw Constraints', this.drawConstraints, (checked) => this.drawConstraints = checked);
+		BodyDrawSettingsMap.forEach(item => {
+			if (item.header) {
+				const header = document.createElement('h4');
+				header.innerText = item.header;
+				this.domElement.append(header);
+			}
+			else {
+				if (item.options) {
+					const label = document.createElement('label');
+					label.innerText = item.label + '\n';
+					this.domElement.append(label);
+					const options = document.createElement('select');
+					item.options.forEach(option => {
+						const o = document.createElement('option');
+						o.innerText = option.label;
+						o.value = option.key;
+						options.append(o);
+					});
+					options.onchange = () => {
+						this.bodyDrawSettings[item.key] = Jolt[options.value];
+					};
+					label.append(options);
+				}
+				else {
+					this.addCheckBox(item.label, this.bodyDrawSettings[item.key], (checked) => this.bodyDrawSettings[item.key] = checked);
+				}
+			}
+		});
+	}
+	addCheckBox(labelText, initialValue, onChange) {
+		const label = document.createElement('label');
+		label.innerText = labelText;
+		this.domElement.append(label);
+		const check = document.createElement('input');
+		check.type = 'checkbox';
+		check.checked = initialValue;
+		check.onclick = () => { onChange(check.checked); };
+		label.append(check);
+	}
+	render() {
+		this.renderer.Initialize();
+		if (this.drawBodies)
+			this.renderer.DrawBodies(physicsSystem, this.bodyDrawSettings);
+		if (this.drawConstraints) {
+			this.renderer.DrawConstraints(physicsSystem);
+			this.renderer.DrawConstraintLimits(physicsSystem);
+		}
+		this.renderer.Render();
+	}
+}

--- a/Examples/js/debug-renderer.js
+++ b/Examples/js/debug-renderer.js
@@ -29,15 +29,15 @@ class DebugRenderer {
 			this.initialized = true;
 		}
 	}
-    // Draws all bodies, assuming DrawSettings has mDrawShape enabled
+	// Draws all bodies, assuming DrawSettings has mDrawShape enabled
 	DrawBodies(system, inDrawSettings) {
 		this.renderer.DrawBodies(system, inDrawSettings);
 	}
-    // Draws constraint relationships as lines. Some constraints include additional Text Data
+	// Draws constraint relationships as lines. Some constraints include additional Text Data
 	DrawConstraints(system) {
 		this.renderer.DrawConstraints(system);
 	}
-    // Draws text indicating limits on constraints, such as the distance of a distance constraint
+	// Draws text indicating limits on constraints, such as the distance of a distance constraint
 	DrawConstraintLimits(system) {
 		this.renderer.DrawConstraintLimits(system);
 	}
@@ -66,7 +66,7 @@ class DebugRenderer {
 		const text = textDecoder.decode(Jolt.HEAPU8.subarray(inStringPtr, inStringPtr + inStringLen));
 		this.textList.push({ color, position, height, text });
 	}
-    // Assuming a Render Geometry/Batch has been created, the following is a request to render the Geometry at a given model location
+	// Assuming a Render Geometry/Batch has been created, the following is a request to render the Geometry at a given model location
 	drawGeometryWithID(inModelMatrix, inWorldSpaceBounds, inLODScaleSq, inModelColor, inGeometryID, inCullMode, inCastShadow, inDrawMode) {
 		const colorU32 = Jolt.wrapPointer(inModelColor, Jolt.Color).mU32 >>> 0;
 		const modelMatrix = Jolt.wrapPointer(inModelMatrix, Jolt.RMat44);
@@ -77,15 +77,15 @@ class DebugRenderer {
 		const matrix = new THREE.Matrix4().makeBasis(v0, v1, v2).setPosition(v3);
 		this.geometryList.push({ matrix: matrix, geometry: this.geometryCache[inGeometryID], color: colorU32, drawMode: inDrawMode, cullMode: inCullMode });
 	}
-    // On initializing the Renderer, or adding new rigid Mesh, the following methods will send the vertex data here to construct a Render Geometry
+	// On initializing the Renderer, or adding new rigid Mesh, the following methods will send the vertex data here to construct a Render Geometry
 	createTriangleBatchID(inTriangles, inTriangleCount) {
 		const batchID = this.geometryCache.length;
 		const { mPositionOffset, mNormalOffset, mUVOffset, mSize } = Jolt.DebugRendererVertexTraits.prototype;
 		const interleaveBufferF32 = new Float32Array(inTriangleCount * 3 * mSize / 4);
 
-        // Assuming a triangle is tightly packed (always 3 vertex with no leading or trailing space), we can treat the data chunk
-        // as a whole as if it was an interleaved vertex buffer, assuming no alignment issues such that element N+1 is more than (size) from element N+0
-        // This case is always true as of this coding, but should it not be, the following [else] case will extract just the 3 vertex
+		// Assuming a triangle is tightly packed (always 3 vertex with no leading or trailing space), we can treat the data chunk
+		// as a whole as if it was an interleaved vertex buffer, assuming no alignment issues such that element N+1 is more than (size) from element N+0
+		// This case is always true as of this coding, but should it not be, the following [else] case will extract just the 3 vertex
 		if (Jolt.DebugRendererTriangleTraits.prototype.mVOffset === 0 && Jolt.DebugRendererTriangleTraits.prototype.mSize === mSize * 3) {
 			interleaveBufferF32.set(new Float32Array(Jolt.HEAPF32.buffer, inTriangles, interleaveBufferF32.length));
 		}
@@ -112,7 +112,7 @@ class DebugRenderer {
 		interleaveBufferF32.set(new Float32Array(Jolt.HEAPF32.buffer, inVertices, interleaveBufferF32.length));
 		const index = new Uint32Array(inIndexCount);
 
-        // Unlike triangles, by definition this data will be an interleaved data buffer
+		// Unlike triangles, by definition this data will be an interleaved data buffer
 		index.set(Jolt.HEAPU32.subarray(inIndices / 4, inIndices / 4 + inIndexCount));
 		// Create a three mesh
 		const geometry = new THREE.BufferGeometry();
@@ -124,8 +124,8 @@ class DebugRenderer {
 		this.geometryCache.push(geometry);
 		return batchID;
 	}
-    // Debug Renderer supports applying color, Front and Back face culling, and drawing as solid or wire frame.
-    // These all correspond to different Three Materials, so cache them here.
+	// Debug Renderer supports applying color, Front and Back face culling, and drawing as solid or wire frame.
+	// These all correspond to different Three Materials, so cache them here.
 	getMeshMaterial(color, cullMode, drawMode) {
 		const key = `${color}|${cullMode}|${drawMode}`;
 		if (!this.materialCache[key]) {
@@ -149,11 +149,11 @@ class DebugRenderer {
 		}
 		return this.materialCache[key];
 	}
-    // The following call flushes all accumulated Draw calls to new or existing Meshes that have been cached.
-    // Line/Triangle calls are combined into single Meshes per material.
-    // Text3D calls trigger a lazy initialization of CSS3D Render to render the text as transformed DIVs
+	// The following call flushes all accumulated Draw calls to new or existing Meshes that have been cached.
+	// Line/Triangle calls are combined into single Meshes per material.
+	// Text3D calls trigger a lazy initialization of CSS3D Render to render the text as transformed DIVs
 	Render() {
-        // Clear previous frames meshes, in case this frame no longer has these meshes.
+		// Clear previous frames meshes, in case this frame no longer has these meshes.
 		[Object.values(this.lineMesh), Object.values(this.triangleMesh), this.meshList, this.textCache].forEach(meshes => {
 			meshes.forEach(mesh => mesh.visible = false);
 		});
@@ -205,7 +205,7 @@ class DebugRenderer {
 		this.textList.forEach(({ position, text, color, height }, i) => {
 			let mesh = this.textCache[i];
 			if (!this.css3dRender) {
-                // Lazy construct a CSS3D Renderer.
+				// Lazy construct a CSS3D Renderer.
 				this.css3dRender = new THREE.CSS3DRenderer();
 				const renderSize = new THREE.Vector2();
 				renderer.getSize(renderSize);
@@ -214,7 +214,7 @@ class DebugRenderer {
 				element.style.position = 'absolute';
 				element.style.left = element.style.right = element.style.top = element.style.bottom = '0';
 				document.getElementById('container')?.append(element);
-                window.addEventListener('resize', () => { renderer.getSize(renderSize); this.css3dRender.setSize(renderSize.x, renderSize.y);}, false);
+				window.addEventListener('resize', () => { renderer.getSize(renderSize); this.css3dRender.setSize(renderSize.x, renderSize.y); }, false);
 			}
 			if (!mesh) {
 				mesh = this.textCache[i] = new THREE.CSS3DObject(document.createElement('div'));
@@ -230,9 +230,9 @@ class DebugRenderer {
 			mesh.position.copy(position);
 			mesh.visible = true;
 		});
-        // Render the CSS 3D here (updates the DIV locations and css transforms)
+		// Render the CSS 3D here (updates the DIV locations and css transforms)
 		this.css3dRender && this.css3dRender.render(scene, camera);
-        // Clear the accumulators of [Draw] requests
+		// Clear the accumulators of [Draw] requests
 		this.geometryList = [];
 		this.textList = [];
 		this.lineCache = {};
@@ -244,14 +244,16 @@ class DebugRenderer {
 const BodyDrawSettingsMap = [
 	{ key: 'mDrawShape', label: 'Shape' },
 	{ key: 'mDrawShapeWireframe', label: 'Shape Wireframe' },
-	{ key: 'mDrawShapeColor', label: 'Shape Color', options: [
+	{
+		key: 'mDrawShapeColor', label: 'Shape Color', options: [
 			{ key: "EShapeColor_InstanceColor", label: 'Instance Color' },
 			{ key: "EShapeColor_ShapeTypeColor", label: 'Shape Type Color' },
 			{ key: "EShapeColor_MotionTypeColor", label: 'Motion Color' },
 			{ key: "EShapeColor_SleepColor", label: 'Sleep Color' },
 			{ key: "EShapeColor_IslandColor", label: 'Island Color' },
 			{ key: "EShapeColor_MaterialColor", label: 'Material Color' }
-		] },
+		]
+	},
 	{ key: 'mDrawBoundingBox', label: 'Bounding Box' },
 	{ key: 'mDrawCenterOfMassTransform', label: 'Center of Mass Transform' },
 	{ key: 'mDrawWorldTransform', label: 'World Transform' },
@@ -296,13 +298,13 @@ class RenderWidget {
 	}
 	init() {
 		// The scene and all existing lights should be visible in Layers 0x1 and 0x2
-		scene.traverse((x) => {if(x.isLight) x.layers.mask = 3});
+		scene.traverse((x) => { if (x.isLight) x.layers.mask = 3 });
 		scene.layers.mask = 3;
 		const renderMask = document.createElement('select');
 		renderMask.innerHTML = `<option value='1' selected>ORIGINAL</option><option value='2'>DEBUG</option><option value='3'>BOTH</option>`;
 		renderMask.onchange = () => { camera.layers.mask = parseInt(renderMask.value, 10); }
 		this.domElement.append(renderMask);
-	  this.addCheckBox('Draw Bodies', this.drawBodies, (checked) => this.drawBodies = checked);
+		this.addCheckBox('Draw Bodies', this.drawBodies, (checked) => this.drawBodies = checked);
 		this.addCheckBox('Draw Constraints', this.drawConstraints, (checked) => this.drawConstraints = checked);
 		BodyDrawSettingsMap.forEach(item => {
 			if (item.header) {

--- a/Examples/js/debug-renderer.js
+++ b/Examples/js/debug-renderer.js
@@ -295,14 +295,12 @@ class RenderWidget {
 		button.onclick = () => { this.domElement.classList.toggle('collapsed'); collapsed = !collapsed; button.innerText = collapsed ? 'SHOW' : 'HIDE'; };
 	}
 	init() {
-		const dirLight = new THREE.DirectionalLight(0xffffff, 1);
-		dirLight.position.set(10, 10, 5);
-		dirLight.layers.set(1);
-		scene.add(dirLight);
+		// The scene and all existing lights should be visible in Layers 0x1 and 0x2
+		scene.traverse((x) => {if(x.isLight) x.layers.mask = 3});
 		scene.layers.mask = 3;
 		const renderMask = document.createElement('select');
 		renderMask.innerHTML = `<option value='1' selected>ORIGINAL</option><option value='2'>DEBUG</option><option value='3'>BOTH</option>`;
-		renderMask.onchange = () => camera.layers.mask = parseInt(renderMask.value, 10);
+		renderMask.onchange = () => { camera.layers.mask = parseInt(renderMask.value, 10); }
 		this.domElement.append(renderMask);
 	  this.addCheckBox('Draw Bodies', this.drawBodies, (checked) => this.drawBodies = checked);
 		this.addCheckBox('Draw Constraints', this.drawConstraints, (checked) => this.drawConstraints = checked);

--- a/Examples/js/three/CSS3DRenderer.js
+++ b/Examples/js/three/CSS3DRenderer.js
@@ -1,0 +1,333 @@
+(function() {
+const {
+	Matrix4,
+	Object3D,
+	Quaternion,
+	Vector3
+} = THREE;
+
+/**
+ * Based on http://www.emagix.net/academic/mscs-project/item/camera-sync-with-css3-and-webgl-threejs
+ */
+
+const _position = new Vector3();
+const _quaternion = new Quaternion();
+const _scale = new Vector3();
+
+class CSS3DObject extends Object3D {
+
+	constructor( element = document.createElement( 'div' ) ) {
+
+		super();
+
+		this.isCSS3DObject = true;
+
+		this.element = element;
+		this.element.style.position = 'absolute';
+		this.element.style.pointerEvents = 'auto';
+		this.element.style.userSelect = 'none';
+
+		this.element.setAttribute( 'draggable', false );
+
+		this.addEventListener( 'removed', function () {
+
+			this.traverse( function ( object ) {
+
+				if ( object.element instanceof Element && object.element.parentNode !== null ) {
+
+					object.element.parentNode.removeChild( object.element );
+
+				}
+
+			} );
+
+		} );
+
+	}
+
+	copy( source, recursive ) {
+
+		super.copy( source, recursive );
+
+		this.element = source.element.cloneNode( true );
+
+		return this;
+
+	}
+
+}
+
+class CSS3DSprite extends CSS3DObject {
+
+	constructor( element ) {
+
+		super( element );
+
+		this.isCSS3DSprite = true;
+
+		this.rotation2D = 0;
+
+	}
+
+	copy( source, recursive ) {
+
+		super.copy( source, recursive );
+
+		this.rotation2D = source.rotation2D;
+
+		return this;
+
+	}
+
+}
+
+//
+
+const _matrix = new Matrix4();
+const _matrix2 = new Matrix4();
+
+class CSS3DRenderer {
+
+	constructor( parameters = {} ) {
+
+		const _this = this;
+
+		let _width, _height;
+		let _widthHalf, _heightHalf;
+
+		const cache = {
+			camera: { style: '' },
+			objects: new WeakMap()
+		};
+
+		const domElement = parameters.element !== undefined ? parameters.element : document.createElement( 'div' );
+
+		domElement.style.overflow = 'hidden';
+
+		this.domElement = domElement;
+
+		const viewElement = document.createElement( 'div' );
+		viewElement.style.transformOrigin = '0 0';
+		viewElement.style.pointerEvents = 'none';
+		domElement.appendChild( viewElement );
+
+		const cameraElement = document.createElement( 'div' );
+
+		cameraElement.style.transformStyle = 'preserve-3d';
+
+		viewElement.appendChild( cameraElement );
+
+		this.getSize = function () {
+
+			return {
+				width: _width,
+				height: _height
+			};
+
+		};
+
+		this.render = function ( scene, camera ) {
+
+			const fov = camera.projectionMatrix.elements[ 5 ] * _heightHalf;
+
+			if ( camera.view && camera.view.enabled ) {
+
+				// view offset
+				viewElement.style.transform = `translate( ${ - camera.view.offsetX * ( _width / camera.view.width ) }px, ${ - camera.view.offsetY * ( _height / camera.view.height ) }px )`;
+
+				// view fullWidth and fullHeight, view width and height
+				viewElement.style.transform += `scale( ${ camera.view.fullWidth / camera.view.width }, ${ camera.view.fullHeight / camera.view.height } )`;
+
+			} else {
+
+				viewElement.style.transform = '';
+
+			}
+
+			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+
+			let tx, ty;
+
+			if ( camera.isOrthographicCamera ) {
+
+				tx = - ( camera.right + camera.left ) / 2;
+				ty = ( camera.top + camera.bottom ) / 2;
+
+			}
+
+			const scaleByViewOffset = camera.view && camera.view.enabled ? camera.view.height / camera.view.fullHeight : 1;
+			const cameraCSSMatrix = camera.isOrthographicCamera ?
+				`scale( ${ scaleByViewOffset } )` + 'scale(' + fov + ')' + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
+				`scale( ${ scaleByViewOffset } )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
+			const perspective = camera.isPerspectiveCamera ? 'perspective(' + fov + 'px) ' : '';
+
+			const style = perspective + cameraCSSMatrix +
+				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
+
+			if ( cache.camera.style !== style ) {
+
+				cameraElement.style.transform = style;
+
+				cache.camera.style = style;
+
+			}
+
+			renderObject( scene, scene, camera, cameraCSSMatrix );
+
+		};
+
+		this.setSize = function ( width, height ) {
+
+			_width = width;
+			_height = height;
+			_widthHalf = _width / 2;
+			_heightHalf = _height / 2;
+
+			domElement.style.width = width + 'px';
+			domElement.style.height = height + 'px';
+
+			viewElement.style.width = width + 'px';
+			viewElement.style.height = height + 'px';
+
+			cameraElement.style.width = width + 'px';
+			cameraElement.style.height = height + 'px';
+
+		};
+
+		function epsilon( value ) {
+
+			return Math.abs( value ) < 1e-10 ? 0 : value;
+
+		}
+
+		function getCameraCSSMatrix( matrix ) {
+
+			const elements = matrix.elements;
+
+			return 'matrix3d(' +
+				epsilon( elements[ 0 ] ) + ',' +
+				epsilon( - elements[ 1 ] ) + ',' +
+				epsilon( elements[ 2 ] ) + ',' +
+				epsilon( elements[ 3 ] ) + ',' +
+				epsilon( elements[ 4 ] ) + ',' +
+				epsilon( - elements[ 5 ] ) + ',' +
+				epsilon( elements[ 6 ] ) + ',' +
+				epsilon( elements[ 7 ] ) + ',' +
+				epsilon( elements[ 8 ] ) + ',' +
+				epsilon( - elements[ 9 ] ) + ',' +
+				epsilon( elements[ 10 ] ) + ',' +
+				epsilon( elements[ 11 ] ) + ',' +
+				epsilon( elements[ 12 ] ) + ',' +
+				epsilon( - elements[ 13 ] ) + ',' +
+				epsilon( elements[ 14 ] ) + ',' +
+				epsilon( elements[ 15 ] ) +
+			')';
+
+		}
+
+		function getObjectCSSMatrix( matrix ) {
+
+			const elements = matrix.elements;
+			const matrix3d = 'matrix3d(' +
+				epsilon( elements[ 0 ] ) + ',' +
+				epsilon( elements[ 1 ] ) + ',' +
+				epsilon( elements[ 2 ] ) + ',' +
+				epsilon( elements[ 3 ] ) + ',' +
+				epsilon( - elements[ 4 ] ) + ',' +
+				epsilon( - elements[ 5 ] ) + ',' +
+				epsilon( - elements[ 6 ] ) + ',' +
+				epsilon( - elements[ 7 ] ) + ',' +
+				epsilon( elements[ 8 ] ) + ',' +
+				epsilon( elements[ 9 ] ) + ',' +
+				epsilon( elements[ 10 ] ) + ',' +
+				epsilon( elements[ 11 ] ) + ',' +
+				epsilon( elements[ 12 ] ) + ',' +
+				epsilon( elements[ 13 ] ) + ',' +
+				epsilon( elements[ 14 ] ) + ',' +
+				epsilon( elements[ 15 ] ) +
+			')';
+
+			return 'translate(-50%,-50%)' + matrix3d;
+
+		}
+
+		function renderObject( object, scene, camera, cameraCSSMatrix ) {
+
+			if ( object.isCSS3DObject ) {
+
+				const visible = ( object.visible === true ) && ( object.layers.test( camera.layers ) === true );
+				object.element.style.display = ( visible === true ) ? '' : 'none';
+
+				if ( visible === true ) {
+
+					object.onBeforeRender( _this, scene, camera );
+
+					let style;
+
+					if ( object.isCSS3DSprite ) {
+
+						// http://swiftcoder.wordpress.com/2008/11/25/constructing-a-billboard-matrix/
+
+						_matrix.copy( camera.matrixWorldInverse );
+						_matrix.transpose();
+
+						if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
+
+						object.matrixWorld.decompose( _position, _quaternion, _scale );
+						_matrix.setPosition( _position );
+						_matrix.scale( _scale );
+
+						_matrix.elements[ 3 ] = 0;
+						_matrix.elements[ 7 ] = 0;
+						_matrix.elements[ 11 ] = 0;
+						_matrix.elements[ 15 ] = 1;
+
+						style = getObjectCSSMatrix( _matrix );
+
+					} else {
+
+						style = getObjectCSSMatrix( object.matrixWorld );
+
+					}
+
+					const element = object.element;
+					const cachedObject = cache.objects.get( object );
+
+					if ( cachedObject === undefined || cachedObject.style !== style ) {
+
+						element.style.transform = style;
+
+						const objectData = { style: style };
+						cache.objects.set( object, objectData );
+
+					}
+
+					if ( element.parentNode !== cameraElement ) {
+
+						cameraElement.appendChild( element );
+
+					}
+
+					object.onAfterRender( _this, scene, camera );
+
+				}
+
+			}
+
+			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
+
+				renderObject( object.children[ i ], scene, camera, cameraCSSMatrix );
+
+			}
+
+		}
+
+	}
+
+}
+
+THREE.CSS3DObject = CSS3DObject;
+THREE.CSS3DSprite = CSS3DSprite;
+THREE.CSS3DRenderer = CSS3DRenderer;
+})();

--- a/Examples/render-debug.html
+++ b/Examples/render-debug.html
@@ -32,16 +32,17 @@
 
 	initJolt().then(function (Jolt) {
 
-		const lineUpdates = [];
-		// Initialize this example
-		const debugRendererWidget = new RenderWidget(Jolt);
-		initExample(Jolt, () => {
-			lineUpdates.forEach(func => func());
-
-			debugRendererWidget.render();
-		});
-		debugRendererWidget.init();
-		document.body.appendChild(debugRendererWidget.domElement);
+		if(Jolt.DebugRendererJS) {
+			// Initialize this example
+			const debugRendererWidget = new RenderWidget(Jolt);
+			initExample(Jolt, () => {
+				debugRendererWidget.render();
+			});
+			debugRendererWidget.init();
+			document.body.appendChild(debugRendererWidget.domElement);
+		} else {
+			initExample(Jolt);
+		}
 
 		// Better position the camera
 		camera.position.set(10, 30, 30);

--- a/Examples/render-debug.html
+++ b/Examples/render-debug.html
@@ -26,116 +26,114 @@
 	<script src="js/soft-body-creator.js"></script>
 
 	<script type="module">
-	// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
-	import initJolt from './js/jolt-physics.wasm-compat.js';
+		// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+		import initJolt from './js/jolt-physics.wasm-compat.js';
 
+		initJolt().then(function (Jolt) {
 
-	initJolt().then(function (Jolt) {
-
-		if(Jolt.DebugRendererJS) {
-			// Initialize this example
-			const debugRendererWidget = new RenderWidget(Jolt);
-			initExample(Jolt, () => {
-				debugRendererWidget.render();
-			});
-			debugRendererWidget.init();
-			document.body.appendChild(debugRendererWidget.domElement);
-		} else {
-			initExample(Jolt);
-		}
-
-		// Better position the camera
-		camera.position.set(10, 30, 30);
-
-		// Create a basic floor
-		createFloor();
-
-
-		function xorshift32(a) {
-			a = new Uint32Array([a]);
-			return function () {
-				let x = a[0];
-				x ^= x << 13;
-				x ^= x >> 17;
-				x ^= x << 5;
-				a[0] = x;
-				return a[0] / 0xFFFFFFFF;
+			if (Jolt.DebugRendererJS) {
+				// Initialize this example
+				const debugRendererWidget = new RenderWidget(Jolt);
+				initExample(Jolt, () => {
+					debugRendererWidget.render();
+				});
+				debugRendererWidget.init();
+				document.body.appendChild(debugRendererWidget.domElement);
+			} else {
+				initExample(Jolt);
 			}
-		}
 
-		const cNumVerticesX = 10;
-		const cNumVerticesZ = 30;
-		const cVertexSpacing = 0.5;
-		const inv_mass = (x, z) => z < 2 ? 0 : 1;
-		const random_float = (v) => 0.2 * v - 0.1;
-		const perturbation = (seed) => {
-			const random = xorshift32(seed);
-			return (_x, inZ) => ({
-				x: random_float(random()),
-				y: inZ & 1 ? 0.1 : -0.1,
-				z: random_float(random())
-			});
-		}
+			// Better position the camera
+			camera.position.set(10, 30, 30);
 
-		const rotation = Jolt.Quat.prototype.sIdentity();
-		const position = new Jolt.RVec3();
-		{
-			// Cloth with dihedral bend constraints
-			const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_Dihedral);
-			position.Set(5, 10, 0);
-			const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
-			const body = bodyInterface.CreateSoftBody(cloth);
-			addToScene(body, 0x0000aa);
-		}
+			// Create a basic floor
+			createFloor();
 
-		for(let i=0; i<3; i++) {
-			position.Set(-3+i*1.5, 4, 0);
-			const ball = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
-			ball.SetRestitution(0.6 + 0.2 * i);
-		}
-
-		let shape = new Jolt.BoxShape(new Jolt.Vec3(0.5, 0.5, 0.5), 0.05, null);
-		let creationSettings = new Jolt.BodyCreationSettings(shape, new Jolt.RVec3(-15, 20, 0), Jolt.Quat.prototype.sIdentity(), Jolt.EMotionType_Dynamic, LAYER_MOVING);
-
-		function createBody(creationSettings, z) {
-			creationSettings.mMotionType = z == 0 ? Jolt.EMotionType_Static : Jolt.EMotionType_Dynamic;
-			creationSettings.mObjectLayer = z == 0 ? LAYER_NON_MOVING : LAYER_MOVING;
-			creationSettings.mPosition.SetZ(z);
-			creationSettings.mCollisionGroup.SetSubGroupID(z);
-
-			let body = bodyInterface.CreateBody(creationSettings);
-			addToScene(body, 0xff0000);
-
-			// Add an impulse (gravity is really boring, many constraints look the same)
-			if (z == 9)
-				body.AddImpulse(new Jolt.Vec3(1000, 0, 0));
-
-			return body;
-		}
-		// Distance constraint
-		creationSettings.mCollisionGroup.SetGroupID(creationSettings.mCollisionGroup.GetGroupID() + 1);
-		creationSettings.mPosition.SetX(creationSettings.mPosition.GetX() + 5);
-		{
-			let constraintSettings = new Jolt.DistanceConstraintSettings();
-			constraintSettings.mPoint1 = constraintSettings.mPoint2 = creationSettings.mPosition;
-			constraintSettings.mMinDistance = 0;
-			constraintSettings.mMaxDistance = 1;
-			let prevBody = null;
-
-			for (let z = 0; z < 10; ++z) {
-				let body = createBody(creationSettings, z);
-
-				if (prevBody != null) {
-					constraintSettings.mPoint1.SetZ(z - 0.5);
-					constraintSettings.mPoint2.SetZ(z - 0.5);
-					physicsSystem.AddConstraint(constraintSettings.Create(prevBody, body));
+			function xorshift32(a) {
+				a = new Uint32Array([a]);
+				return function () {
+					let x = a[0];
+					x ^= x << 13;
+					x ^= x >> 17;
+					x ^= x << 5;
+					a[0] = x;
+					return a[0] / 0xFFFFFFFF;
 				}
-
-				prevBody = body;
 			}
-		}
 
-	});
+			const cNumVerticesX = 10;
+			const cNumVerticesZ = 30;
+			const cVertexSpacing = 0.5;
+			const inv_mass = (x, z) => z < 2 ? 0 : 1;
+			const random_float = (v) => 0.2 * v - 0.1;
+			const perturbation = (seed) => {
+				const random = xorshift32(seed);
+				return (_x, inZ) => ({
+					x: random_float(random()),
+					y: inZ & 1 ? 0.1 : -0.1,
+					z: random_float(random())
+				});
+			}
+
+			const rotation = Jolt.Quat.prototype.sIdentity();
+			const position = new Jolt.RVec3();
+			{
+				// Cloth with dihedral bend constraints
+				const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_Dihedral);
+				position.Set(5, 10, 0);
+				const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+				const body = bodyInterface.CreateSoftBody(cloth);
+				addToScene(body, 0x0000aa);
+			}
+
+			for (let i = 0; i < 3; i++) {
+				position.Set(-3 + i * 1.5, 4, 0);
+				const ball = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+				ball.SetRestitution(0.6 + 0.2 * i);
+			}
+
+			let shape = new Jolt.BoxShape(new Jolt.Vec3(0.5, 0.5, 0.5), 0.05, null);
+			let creationSettings = new Jolt.BodyCreationSettings(shape, new Jolt.RVec3(-15, 20, 0), Jolt.Quat.prototype.sIdentity(), Jolt.EMotionType_Dynamic, LAYER_MOVING);
+
+			function createBody(creationSettings, z) {
+				creationSettings.mMotionType = z == 0 ? Jolt.EMotionType_Static : Jolt.EMotionType_Dynamic;
+				creationSettings.mObjectLayer = z == 0 ? LAYER_NON_MOVING : LAYER_MOVING;
+				creationSettings.mPosition.SetZ(z);
+				creationSettings.mCollisionGroup.SetSubGroupID(z);
+
+				let body = bodyInterface.CreateBody(creationSettings);
+				addToScene(body, 0xff0000);
+
+				// Add an impulse (gravity is really boring, many constraints look the same)
+				if (z == 9)
+					body.AddImpulse(new Jolt.Vec3(1000, 0, 0));
+
+				return body;
+			}
+
+			// Distance constraint
+			creationSettings.mCollisionGroup.SetGroupID(creationSettings.mCollisionGroup.GetGroupID() + 1);
+			creationSettings.mPosition.SetX(creationSettings.mPosition.GetX() + 5);
+			{
+				let constraintSettings = new Jolt.DistanceConstraintSettings();
+				constraintSettings.mPoint1 = constraintSettings.mPoint2 = creationSettings.mPosition;
+				constraintSettings.mMinDistance = 0;
+				constraintSettings.mMaxDistance = 1;
+				let prevBody = null;
+
+				for (let z = 0; z < 10; ++z) {
+					let body = createBody(creationSettings, z);
+
+					if (prevBody != null) {
+						constraintSettings.mPoint1.SetZ(z - 0.5);
+						constraintSettings.mPoint2.SetZ(z - 0.5);
+						physicsSystem.AddConstraint(constraintSettings.Create(prevBody, body));
+					}
+
+					prevBody = body;
+				}
+			}
+		});
 	</script>
 </body>
 </html>

--- a/Examples/render-debug.html
+++ b/Examples/render-debug.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>JoltPhysics.js demo</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+	<div id="container">Loading...</div>
+	<div id="info">
+		JoltPhysics.js Debug Renderer<br />
+		This demo shows various debug renderer settings<br />
+		Left: This demonstrates some data shown for Constraint drawing. Different constraints have different data displayed.<br />
+		Center: The bouncing ball demonstrates the velocity vector data and items falling asleep (sleep stats, shape color: sleep)<br />
+		Right: The cloth demonstrates Soft Body settings: vertices, velocities, edge, and bend constraints.
+	</div>
+
+	<script src="js/three/three.min.js"></script>
+	<script src="js/three/OrbitControls.js"></script>
+	<script src="js/three/WebGL.js"></script>
+	<script src="js/three/stats.min.js"></script>
+	<script src="js/three/CSS3DRenderer.js"></script>
+	<script src="js/debug-renderer.js"></script>
+	<script src="js/example.js"></script>
+	<script src="js/soft-body-creator.js"></script>
+
+	<script type="module">
+	// In case you haven't built the library yourself, replace URL with: https://www.unpkg.com/jolt-physics/dist/jolt-physics.wasm-compat.js
+	import initJolt from './js/jolt-physics.wasm-compat.js';
+
+
+	initJolt().then(function (Jolt) {
+
+		const lineUpdates = [];
+		// Initialize this example
+		const debugRendererWidget = new RenderWidget(Jolt);
+		initExample(Jolt, () => {
+			lineUpdates.forEach(func => func());
+
+			debugRendererWidget.render();
+		});
+		debugRendererWidget.init();
+		document.body.appendChild(debugRendererWidget.domElement);
+
+		// Better position the camera
+		camera.position.set(10, 30, 30);
+
+		// Create a basic floor
+		createFloor();
+
+
+		function xorshift32(a) {
+			a = new Uint32Array([a]);
+			return function () {
+				let x = a[0];
+				x ^= x << 13;
+				x ^= x >> 17;
+				x ^= x << 5;
+				a[0] = x;
+				return a[0] / 0xFFFFFFFF;
+			}
+		}
+
+		const cNumVerticesX = 10;
+		const cNumVerticesZ = 30;
+		const cVertexSpacing = 0.5;
+		const inv_mass = (x, z) => z < 2 ? 0 : 1;
+		const random_float = (v) => 0.2 * v - 0.1;
+		const perturbation = (seed) => {
+			const random = xorshift32(seed);
+			return (_x, inZ) => ({
+				x: random_float(random()),
+				y: inZ & 1 ? 0.1 : -0.1,
+				z: random_float(random())
+			});
+		}
+
+		const rotation = Jolt.Quat.prototype.sIdentity();
+		const position = new Jolt.RVec3();
+		{
+			// Cloth with dihedral bend constraints
+			const cloth_settings = SoftBodyCreator.CreateCloth(cNumVerticesX, cNumVerticesZ, cVertexSpacing, inv_mass, perturbation(1234), Jolt.SoftBodySharedSettings_EBendType_Dihedral);
+			position.Set(5, 10, 0);
+			const cloth = new Jolt.SoftBodyCreationSettings(cloth_settings, position, rotation, LAYER_MOVING);
+			const body = bodyInterface.CreateSoftBody(cloth);
+			addToScene(body, 0x0000aa);
+		}
+
+		for(let i=0; i<3; i++) {
+			position.Set(-3+i*1.5, 4, 0);
+			const ball = createSphere(position, 0.5, Jolt.EMotionType_Dynamic, LAYER_MOVING);
+			ball.SetRestitution(0.6 + 0.2 * i);
+		}
+
+		let shape = new Jolt.BoxShape(new Jolt.Vec3(0.5, 0.5, 0.5), 0.05, null);
+		let creationSettings = new Jolt.BodyCreationSettings(shape, new Jolt.RVec3(-15, 20, 0), Jolt.Quat.prototype.sIdentity(), Jolt.EMotionType_Dynamic, LAYER_MOVING);
+
+		function createBody(creationSettings, z) {
+			creationSettings.mMotionType = z == 0 ? Jolt.EMotionType_Static : Jolt.EMotionType_Dynamic;
+			creationSettings.mObjectLayer = z == 0 ? LAYER_NON_MOVING : LAYER_MOVING;
+			creationSettings.mPosition.SetZ(z);
+			creationSettings.mCollisionGroup.SetSubGroupID(z);
+
+			let body = bodyInterface.CreateBody(creationSettings);
+			addToScene(body, 0xff0000);
+
+			// Add an impulse (gravity is really boring, many constraints look the same)
+			if (z == 9)
+				body.AddImpulse(new Jolt.Vec3(1000, 0, 0));
+
+			return body;
+		}
+		// Distance constraint
+		creationSettings.mCollisionGroup.SetGroupID(creationSettings.mCollisionGroup.GetGroupID() + 1);
+		creationSettings.mPosition.SetX(creationSettings.mPosition.GetX() + 5);
+		{
+			let constraintSettings = new Jolt.DistanceConstraintSettings();
+			constraintSettings.mPoint1 = constraintSettings.mPoint2 = creationSettings.mPosition;
+			constraintSettings.mMinDistance = 0;
+			constraintSettings.mMaxDistance = 1;
+			let prevBody = null;
+
+			for (let z = 0; z < 10; ++z) {
+				let body = createBody(creationSettings, z);
+
+				if (prevBody != null) {
+					constraintSettings.mPoint1.SetZ(z - 0.5);
+					constraintSettings.mPoint2.SetZ(z - 0.5);
+					physicsSystem.AddConstraint(constraintSettings.Create(prevBody, body));
+				}
+
+				prevBody = body;
+			}
+		}
+
+	});
+	</script>
+</body>
+</html>

--- a/JoltJS-DebugRenderer.h
+++ b/JoltJS-DebugRenderer.h
@@ -5,7 +5,6 @@ using DebugRendererVertex = DebugRenderer::Vertex;
 using DebugRendererTriangle = DebugRenderer::Triangle;
 
 using ECullMode = DebugRenderer::ECullMode;
-
 constexpr ECullMode ECullMode_CullBackFace = ECullMode::CullBackFace;
 constexpr ECullMode ECullMode_CullFrontFace = ECullMode::CullFrontFace;
 constexpr ECullMode ECullMode_Off = ECullMode::Off;
@@ -14,13 +13,11 @@ using ECastShadow = DebugRenderer::ECastShadow;
 constexpr ECastShadow ECastShadow_On = ECastShadow::On;
 constexpr ECastShadow ECastShadow_Off = ECastShadow::Off;
 
-using EDrawMode= DebugRenderer::EDrawMode;
+using EDrawMode = DebugRenderer::EDrawMode;
 constexpr EDrawMode EDrawMode_Solid = EDrawMode::Solid;
 constexpr EDrawMode EDrawMode_Wireframe = EDrawMode::Wireframe;
 
-
-
-using EShapeColor= BodyManager::EShapeColor;
+using EShapeColor = BodyManager::EShapeColor;
 constexpr EShapeColor EShapeColor_InstanceColor = EShapeColor::InstanceColor;
 constexpr EShapeColor EShapeColor_ShapeTypeColor = EShapeColor::ShapeTypeColor;
 constexpr EShapeColor EShapeColor_MotionTypeColor = EShapeColor::MotionTypeColor;
@@ -28,12 +25,9 @@ constexpr EShapeColor EShapeColor_SleepColor = EShapeColor::SleepColor;
 constexpr EShapeColor EShapeColor_IslandColor = EShapeColor::IslandColor;
 constexpr EShapeColor EShapeColor_MaterialColor = EShapeColor::MaterialColor;
 
-
-/*
-using ESoftBodyConstraintColor = BodyManager::ESoftBodyConstraintColor;
 constexpr ESoftBodyConstraintColor ESoftBodyConstraintColor_ConstraintType = ESoftBodyConstraintColor::ConstraintType;
 constexpr ESoftBodyConstraintColor ESoftBodyConstraintColor_ConstraintGroup = ESoftBodyConstraintColor::ConstraintGroup;
-*/
+constexpr ESoftBodyConstraintColor ESoftBodyConstraintColor_ConstraintOrder = ESoftBodyConstraintColor::ConstraintOrder;
 
 class DebugRendererVertexTraits
 {
@@ -53,74 +47,99 @@ public:
 
 class DebugRendererEm : public JPH::DebugRenderer
 {
-  public:
+public:
+	void 			Initialize()
+	{
+		JPH::DebugRenderer::Initialize();
+	}
 
-  void Initialize() {
-    JPH::DebugRenderer::Initialize();
-  }
+	virtual void	DrawLine(const RVec3 *inFrom, const RVec3 *inTo, const Color *inColor) = 0;
 
-  virtual void DrawLine(const RVec3 *inFrom, const RVec3 *inTo, const Color *inColor) = 0;
-  virtual void DrawLine(RVec3Arg inFrom, RVec3Arg inTo, ColorArg inColor) {
-    DrawLine(&inFrom, &inTo, &inColor);
-  }
+	virtual void	DrawLine(RVec3Arg inFrom, RVec3Arg inTo, ColorArg inColor)
+	{
+		DrawLine(&inFrom, &inTo, &inColor);
+	}
 
-  virtual void DrawTriangle(const RVec3 *inV1, const RVec3 *inV2, const RVec3 *inV3, const Color *inColor, ECastShadow inCastShadow = ECastShadow::Off) = 0;
-  virtual void DrawTriangle(RVec3Arg inV1, RVec3Arg inV2, RVec3Arg inV3, ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off) {
-    DrawTriangle(&inV1, &inV2, &inV3, &inColor, inCastShadow);
-  }
+	virtual void	DrawTriangle(const RVec3 *inV1, const RVec3 *inV2, const RVec3 *inV3, const Color *inColor, ECastShadow inCastShadow = ECastShadow::Off) = 0;
 
-  virtual void DrawText3D(const RVec3 *inPosition, const void *inString, uint32 inStringLen, const Color *inColor, float inHeight) = 0;
-  virtual void DrawText3D(RVec3Arg inPosition, const string_view &inString, ColorArg inColor, float inHeight) {
-    DrawText3D(&inPosition, (const void*)inString.data(), inString.size(), &inColor, inHeight);
-  }
+	virtual void	DrawTriangle(RVec3Arg inV1, RVec3Arg inV2, RVec3Arg inV3, ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off)
+	{
+		DrawTriangle(&inV1, &inV2, &inV3, &inColor, inCastShadow);
+	}
 
-  virtual uint32 CreateTriangleBatchID(const void *inTriangles, int inTriangleCount) = 0;
-  virtual Batch CreateTriangleBatch(const Triangle *inTriangles, int inTriangleCount)
-  {
-    uint32 batch = CreateTriangleBatchID((const void*)inTriangles, inTriangleCount);
-    return new BatchImpl(batch);
-  }
+	virtual void	DrawText3D(const RVec3 *inPosition, const void *inString, uint32 inStringLen, const Color *inColor, float inHeight) = 0;
 
-  virtual uint32 CreateTriangleBatchIDWithIndex(const void *inVertices, int inVertexCount, const void *inIndices, int inIndexCount) = 0;
-  virtual Batch CreateTriangleBatch(const Vertex *inVertices, int inVertexCount, const uint32 *inIndices, int inIndexCount)
-  {
-    uint32 batch = CreateTriangleBatchIDWithIndex((const void*)inVertices, inVertexCount, (const void*)inIndices, inIndexCount);
-    return new BatchImpl(batch);
-  }
+	virtual void	DrawText3D(RVec3Arg inPosition, const string_view &inString, ColorArg inColor, float inHeight)
+	{
+		DrawText3D(&inPosition, (const void*)inString.data(), inString.size(), &inColor, inHeight);
+	}
 
-  virtual void DrawGeometryWithID(const RMat44 *inModelMatrix, const AABox *inWorldSpaceBounds, float inLODScaleSq, Color *inModelColor, const uint32 inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode) = 0;
-  virtual void DrawGeometry(RMat44Arg inModelMatrix, const AABox &inWorldSpaceBounds, float inLODScaleSq, ColorArg inModelColor, const GeometryRef &inGeometry, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode)
-  {
-	  const LOD *lod = inGeometry->mLODs.data();
-	  const BatchImpl *batch = static_cast<const BatchImpl *>(lod->mTriangleBatch.GetPtr());
+	virtual uint32	CreateTriangleBatchID(const void *inTriangles, int inTriangleCount) = 0;
 
-    DrawGeometryWithID(&inModelMatrix, &inWorldSpaceBounds, inLODScaleSq, &inModelColor, batch->mID, inCullMode, inCastShadow, inDrawMode);
-  }
-  void DrawBodies(PhysicsSystem* system, BodyManager::DrawSettings *inDrawSettings) {
-	  system->DrawBodies(*inDrawSettings, this);
-  }
-  void DrawBodies(PhysicsSystem* system) {
-	  system->DrawBodies(BodyManager::DrawSettings(), this);
-  }
-  void DrawConstraints(PhysicsSystem* system) {
-	  system->DrawConstraints(this);
-  }
-  void DrawConstraintLimits(PhysicsSystem* system) {
-	  system->DrawConstraintLimits(this);
-  }
-  void DrawConstraintReferenceFrame(PhysicsSystem* system) {
-	  system->DrawConstraintReferenceFrame(this);
-  }
-  void DrawShape(Shape* inShape, const RMat44 *inModelMatrix, const RVec3 *inScale, const Color * inColor, bool inDrawWireFrame) {
-    inShape->Draw(this, *inModelMatrix, *inScale, *inColor, false, inDrawWireFrame);
-  }
-  void DrawBody(Body* body, const Color * inColor, bool inDrawWireFrame) {
-			RMat44 com = body->GetCenterOfMassTransform();
-			body->GetShape()->Draw(this, com, Vec3::sReplicate(1.0f), *inColor, false, inDrawWireFrame);
-  }
-  void DrawConstraint(Constraint * inConstraint) {
-			inConstraint->DrawConstraint(this);
-  }
+	virtual Batch	CreateTriangleBatch(const Triangle *inTriangles, int inTriangleCount)
+	{
+		uint32 batch = CreateTriangleBatchID((const void*)inTriangles, inTriangleCount);
+		return new BatchImpl(batch);
+	}
+
+	virtual uint32	CreateTriangleBatchIDWithIndex(const void *inVertices, int inVertexCount, const void *inIndices, int inIndexCount) = 0;
+
+	virtual Batch	CreateTriangleBatch(const Vertex *inVertices, int inVertexCount, const uint32 *inIndices, int inIndexCount)
+	{
+		uint32 batch = CreateTriangleBatchIDWithIndex((const void*)inVertices, inVertexCount, (const void*)inIndices, inIndexCount);
+		return new BatchImpl(batch);
+	}
+
+	virtual void	DrawGeometryWithID(const RMat44 *inModelMatrix, const AABox *inWorldSpaceBounds, float inLODScaleSq, Color *inModelColor, const uint32 inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode) = 0;
+
+	virtual void	DrawGeometry(RMat44Arg inModelMatrix, const AABox& inWorldSpaceBounds, float inLODScaleSq, ColorArg inModelColor, const GeometryRef& inGeometry, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode)
+	{
+		const LOD *lod = inGeometry->mLODs.data();
+		const BatchImpl *batch = static_cast<const BatchImpl*>(lod->mTriangleBatch.GetPtr());
+
+		DrawGeometryWithID(&inModelMatrix, &inWorldSpaceBounds, inLODScaleSq, &inModelColor, batch->mID, inCullMode, inCastShadow, inDrawMode);
+	}
+
+	void			DrawBodies(PhysicsSystem *inSystem, BodyManager::DrawSettings *inDrawSettings)
+	{
+		inSystem->DrawBodies(*inDrawSettings, this);
+	}
+	void			DrawBodies(PhysicsSystem *inSystem)
+	{
+		inSystem->DrawBodies(BodyManager::DrawSettings(), this);
+	}
+
+	void			DrawConstraints(PhysicsSystem *inSystem)
+	{
+		inSystem->DrawConstraints(this);
+	}
+
+	void			DrawConstraintLimits(PhysicsSystem *inSystem)
+	{
+		inSystem->DrawConstraintLimits(this);
+	}
+
+	void			DrawConstraintReferenceFrame(PhysicsSystem *inSystem)
+	{
+		inSystem->DrawConstraintReferenceFrame(this);
+	}
+
+	void			DrawShape(Shape *inShape, const RMat44 *inModelMatrix, const RVec3 *inScale, const Color *inColor, bool inDrawWireFrame)
+	{
+		inShape->Draw(this, *inModelMatrix, *inScale, *inColor, false, inDrawWireFrame);
+	}
+
+	void			DrawBody(Body *inBody, const Color *inColor, bool inDrawWireFrame)
+	{
+		RMat44 com = inBody->GetCenterOfMassTransform();
+		inBody->GetShape()->Draw(this, com, Vec3::sReplicate(1.0f), *inColor, false, inDrawWireFrame);
+	}
+
+	void			DrawConstraint(Constraint *inConstraint)
+	{
+		inConstraint->DrawConstraint(this);
+	}
+
 private:
 	/// Implementation specific batch object
 	class BatchImpl : public RefTargetVirtual
@@ -128,12 +147,12 @@ private:
 	public:
 		JPH_OVERRIDE_NEW_DELETE
 
-		BatchImpl(uint32 inID)		: mID(inID) {  }
+							BatchImpl(uint32 inID) : mID(inID) {  }
 
-		virtual void					AddRef() override			{ ++mRefCount; }
-		virtual void					Release() override			{ if (--mRefCount == 0) delete this; }
+		virtual void		AddRef() override { ++mRefCount; }
+		virtual void		Release() override { if (--mRefCount == 0) delete this; }
 
-		atomic<uint32>					mRefCount = 0;
-		uint32							mID;
+		atomic<uint32>		mRefCount = 0;
+		uint32				mID;
 	};
 };

--- a/JoltJS-DebugRenderer.h
+++ b/JoltJS-DebugRenderer.h
@@ -1,0 +1,139 @@
+#include "Jolt/Renderer/DebugRendererSimple.h"
+
+using BodyManagerDrawSettings = BodyManager::DrawSettings;
+using DebugRendererVertex = DebugRenderer::Vertex;
+using DebugRendererTriangle = DebugRenderer::Triangle;
+
+using ECullMode = DebugRenderer::ECullMode;
+
+constexpr ECullMode ECullMode_CullBackFace = ECullMode::CullBackFace;
+constexpr ECullMode ECullMode_CullFrontFace = ECullMode::CullFrontFace;
+constexpr ECullMode ECullMode_Off = ECullMode::Off;
+
+using ECastShadow = DebugRenderer::ECastShadow;
+constexpr ECastShadow ECastShadow_On = ECastShadow::On;
+constexpr ECastShadow ECastShadow_Off = ECastShadow::Off;
+
+using EDrawMode= DebugRenderer::EDrawMode;
+constexpr EDrawMode EDrawMode_Solid = EDrawMode::Solid;
+constexpr EDrawMode EDrawMode_Wireframe = EDrawMode::Wireframe;
+
+
+
+using EShapeColor= BodyManager::EShapeColor;
+constexpr EShapeColor EShapeColor_InstanceColor = EShapeColor::InstanceColor;
+constexpr EShapeColor EShapeColor_ShapeTypeColor = EShapeColor::ShapeTypeColor;
+constexpr EShapeColor EShapeColor_MotionTypeColor = EShapeColor::MotionTypeColor;
+constexpr EShapeColor EShapeColor_SleepColor = EShapeColor::SleepColor;
+constexpr EShapeColor EShapeColor_IslandColor = EShapeColor::IslandColor;
+constexpr EShapeColor EShapeColor_MaterialColor = EShapeColor::MaterialColor;
+
+
+/*
+using ESoftBodyConstraintColor = BodyManager::ESoftBodyConstraintColor;
+constexpr ESoftBodyConstraintColor ESoftBodyConstraintColor_ConstraintType = ESoftBodyConstraintColor::ConstraintType;
+constexpr ESoftBodyConstraintColor ESoftBodyConstraintColor_ConstraintGroup = ESoftBodyConstraintColor::ConstraintGroup;
+*/
+
+class DebugRendererVertexTraits
+{
+public:
+	static constexpr uint mPositionOffset = offsetof(DebugRendererVertex, mPosition);
+	static constexpr uint mNormalOffset = offsetof(DebugRendererVertex, mNormal);
+	static constexpr uint mUVOffset = offsetof(DebugRendererVertex, mUV);
+	static constexpr uint mSize = sizeof(DebugRendererVertex);
+};
+
+class DebugRendererTriangleTraits
+{
+public:
+	static constexpr uint mVOffset = offsetof(DebugRendererTriangle, mV);
+	static constexpr uint mSize = sizeof(DebugRendererTriangle);
+};
+
+class DebugRendererEm : public JPH::DebugRenderer
+{
+  public:
+
+  void Initialize() {
+    JPH::DebugRenderer::Initialize();
+  }
+
+  virtual void DrawLine(const RVec3 *inFrom, const RVec3 *inTo, const Color *inColor) = 0;
+  virtual void DrawLine(RVec3Arg inFrom, RVec3Arg inTo, ColorArg inColor) {
+    DrawLine(&inFrom, &inTo, &inColor);
+  }
+
+  virtual void DrawTriangle(const RVec3 *inV1, const RVec3 *inV2, const RVec3 *inV3, const Color *inColor, ECastShadow inCastShadow = ECastShadow::Off) = 0;
+  virtual void DrawTriangle(RVec3Arg inV1, RVec3Arg inV2, RVec3Arg inV3, ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off) {
+    DrawTriangle(&inV1, &inV2, &inV3, &inColor, inCastShadow);
+  }
+
+  virtual void DrawText3D(const RVec3 *inPosition, const void *inString, uint32 inStringLen, const Color *inColor, float inHeight) = 0;
+  virtual void DrawText3D(RVec3Arg inPosition, const string_view &inString, ColorArg inColor, float inHeight) {
+    DrawText3D(&inPosition, (const void*)inString.data(), inString.size(), &inColor, inHeight);
+  }
+
+  virtual uint32 CreateTriangleBatchID(const void *inTriangles, int inTriangleCount) = 0;
+  virtual Batch CreateTriangleBatch(const Triangle *inTriangles, int inTriangleCount)
+  {
+    uint32 batch = CreateTriangleBatchID((const void*)inTriangles, inTriangleCount);
+    return new BatchImpl(batch);
+  }
+
+  virtual uint32 CreateTriangleBatchIDWithIndex(const void *inVertices, int inVertexCount, const void *inIndices, int inIndexCount) = 0;
+  virtual Batch CreateTriangleBatch(const Vertex *inVertices, int inVertexCount, const uint32 *inIndices, int inIndexCount)
+  {
+    uint32 batch = CreateTriangleBatchIDWithIndex((const void*)inVertices, inVertexCount, (const void*)inIndices, inIndexCount);
+    return new BatchImpl(batch);
+  }
+
+  virtual void DrawGeometryWithID(const RMat44 *inModelMatrix, const AABox *inWorldSpaceBounds, float inLODScaleSq, Color *inModelColor, const uint32 inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode) = 0;
+  virtual void DrawGeometry(RMat44Arg inModelMatrix, const AABox &inWorldSpaceBounds, float inLODScaleSq, ColorArg inModelColor, const GeometryRef &inGeometry, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode)
+  {
+	  const LOD *lod = inGeometry->mLODs.data();
+	  const BatchImpl *batch = static_cast<const BatchImpl *>(lod->mTriangleBatch.GetPtr());
+
+    DrawGeometryWithID(&inModelMatrix, &inWorldSpaceBounds, inLODScaleSq, &inModelColor, batch->mID, inCullMode, inCastShadow, inDrawMode);
+  }
+  void DrawBodies(PhysicsSystem* system, BodyManager::DrawSettings *inDrawSettings) {
+	  system->DrawBodies(*inDrawSettings, this);
+  }
+  void DrawBodies(PhysicsSystem* system) {
+	  system->DrawBodies(BodyManager::DrawSettings(), this);
+  }
+  void DrawConstraints(PhysicsSystem* system) {
+	  system->DrawConstraints(this);
+  }
+  void DrawConstraintLimits(PhysicsSystem* system) {
+	  system->DrawConstraintLimits(this);
+  }
+  void DrawConstraintReferenceFrame(PhysicsSystem* system) {
+	  system->DrawConstraintReferenceFrame(this);
+  }
+  void DrawShape(Shape* inShape, const RMat44 *inModelMatrix, const RVec3 *inScale, const Color * inColor, bool inDrawWireFrame) {
+    inShape->Draw(this, *inModelMatrix, *inScale, *inColor, false, inDrawWireFrame);
+  }
+  void DrawBody(Body* body, const Color * inColor, bool inDrawWireFrame) {
+			RMat44 com = body->GetCenterOfMassTransform();
+			body->GetShape()->Draw(this, com, Vec3::sReplicate(1.0f), *inColor, false, inDrawWireFrame);
+  }
+  void DrawConstraint(Constraint * inConstraint) {
+			inConstraint->DrawConstraint(this);
+  }
+private:
+	/// Implementation specific batch object
+	class BatchImpl : public RefTargetVirtual
+	{
+	public:
+		JPH_OVERRIDE_NEW_DELETE
+
+		BatchImpl(uint32 inID)		: mID(inID) {  }
+
+		virtual void					AddRef() override			{ ++mRefCount; }
+		virtual void					Release() override			{ if (--mRefCount == 0) delete this; }
+
+		atomic<uint32>					mRefCount = 0;
+		uint32							mID;
+	};
+};

--- a/JoltJS-DebugRenderer.idl
+++ b/JoltJS-DebugRenderer.idl
@@ -1,0 +1,92 @@
+
+enum ECullMode {
+  "ECullMode_CullBackFace",
+  "ECullMode_CullFrontFace",
+  "ECullMode_Off" 
+};
+
+enum ECastShadow {
+  "ECastShadow_On" ,
+  "ECastShadow_Off" ,
+};
+
+enum EDrawMode {
+  "EDrawMode_Solid",
+  "EDrawMode_Wireframe",
+};
+
+enum EShapeColor {
+		"EShapeColor_InstanceColor",
+		"EShapeColor_ShapeTypeColor",
+		"EShapeColor_MotionTypeColor",
+		"EShapeColor_SleepColor",
+		"EShapeColor_IslandColor",
+		"EShapeColor_MaterialColor"
+};
+
+interface Color {
+  attribute unsigned long mU32;
+};
+
+interface BodyManagerDrawSettings {
+		void BodyManagerDrawSettings();
+		attribute boolean mDrawGetSupportFunction;
+		attribute boolean mDrawSupportDirection;
+		attribute boolean mDrawGetSupportingFace;
+		attribute boolean mDrawShape;
+		attribute boolean mDrawShapeWireframe;
+		attribute EShapeColor mDrawShapeColor;
+		attribute boolean mDrawBoundingBox;
+		attribute boolean mDrawCenterOfMassTransform;
+		attribute boolean mDrawWorldTransform;
+		attribute boolean mDrawVelocity;
+		attribute boolean mDrawMassAndInertia;
+		attribute boolean mDrawSleepStats;
+		attribute boolean mDrawSoftBodyVertices;
+		attribute boolean mDrawSoftBodyVertexVelocities;
+		attribute boolean mDrawSoftBodyEdgeConstraints;
+		attribute boolean mDrawSoftBodyBendConstraints;
+		attribute boolean mDrawSoftBodyVolumeConstraints;
+		attribute boolean mDrawSoftBodySkinConstraints;
+		attribute boolean mDrawSoftBodyLRAConstraints;
+		attribute boolean mDrawSoftBodyPredictedBounds;
+};
+
+interface DebugRendererVertexTraits
+{
+	static readonly attribute unsigned long mPositionOffset;
+	static readonly attribute unsigned long mNormalOffset;
+	static readonly attribute unsigned long mUVOffset;
+	static readonly attribute unsigned long mSize;
+};
+
+interface DebugRendererTriangleTraits
+{
+	static readonly attribute unsigned long mVOffset;
+	static readonly attribute unsigned long mSize;
+};
+
+
+interface DebugRendererEm { 
+	void Initialize();
+  void DrawBodies(PhysicsSystem system, BodyManagerDrawSettings inDrawSettings);
+  void DrawBodies(PhysicsSystem system);
+  void DrawConstraints(PhysicsSystem system);
+  void DrawConstraintLimits(PhysicsSystem system);
+  void DrawConstraintReferenceFrame(PhysicsSystem system);
+  void DrawShape(Shape inShape, [Const] RMat44 inModelMatrix, [Const] RVec3 inScale, [Const] Color inColor, boolean inDrawWireFrame);
+  void DrawBody(Body body, [Const] Color inColor, boolean inDrawWireFrame);
+  void DrawConstraint(Constraint inConstraint);
+};
+
+[JSImplementation="DebugRendererEm"]
+interface DebugRendererJS: DebugRendererEm {
+  void DebugRendererJS();
+  void DrawLine([Const] RVec3 inFrom, [Const] RVec3 inTo, [Const] Color inColor);
+  void DrawTriangle([Const] RVec3 inV1, [Const] RVec3 inV2,[Const]  RVec3 inV3, [Const] Color inColor, ECastShadow inCastShadow);
+  void DrawText3D([Const] RVec3 inPosition, [Const] any inString, unsigned long inStringLen, [Const] Color inColor, float inHeight);
+  
+  void DrawGeometryWithID([Const] RMat44 inModelMatrix, [Const] AABox inWorldSpaceBounds, float inLODScaleSq, Color inModelColor, [Const] unsigned long inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode);
+  unsigned long CreateTriangleBatchID([Const] any inTriangles, long inTriangleCount);
+  unsigned long CreateTriangleBatchIDWithIndex([Const] any inVertices, long inVertexCount, [Const] any inIndices, long inIndexCount);
+};

--- a/JoltJS-DebugRenderer.idl
+++ b/JoltJS-DebugRenderer.idl
@@ -1,55 +1,62 @@
-
 enum ECullMode {
-  "ECullMode_CullBackFace",
-  "ECullMode_CullFrontFace",
-  "ECullMode_Off" 
+	"ECullMode_CullBackFace",
+	"ECullMode_CullFrontFace",
+	"ECullMode_Off"
 };
 
 enum ECastShadow {
-  "ECastShadow_On" ,
-  "ECastShadow_Off" ,
+	"ECastShadow_On",
+	"ECastShadow_Off",
 };
 
 enum EDrawMode {
-  "EDrawMode_Solid",
-  "EDrawMode_Wireframe",
+	"EDrawMode_Solid",
+	"EDrawMode_Wireframe",
 };
 
 enum EShapeColor {
-		"EShapeColor_InstanceColor",
-		"EShapeColor_ShapeTypeColor",
-		"EShapeColor_MotionTypeColor",
-		"EShapeColor_SleepColor",
-		"EShapeColor_IslandColor",
-		"EShapeColor_MaterialColor"
+	"EShapeColor_InstanceColor",
+	"EShapeColor_ShapeTypeColor",
+	"EShapeColor_MotionTypeColor",
+	"EShapeColor_SleepColor",
+	"EShapeColor_IslandColor",
+	"EShapeColor_MaterialColor"
+};
+
+enum ESoftBodyConstraintColor {
+	"ESoftBodyConstraintColor_ConstraintType",
+	"ESoftBodyConstraintColor_ConstraintGroup",
+	"ESoftBodyConstraintColor_ConstraintOrder"
 };
 
 interface Color {
-  attribute unsigned long mU32;
+	attribute unsigned long mU32;
 };
 
 interface BodyManagerDrawSettings {
-		void BodyManagerDrawSettings();
-		attribute boolean mDrawGetSupportFunction;
-		attribute boolean mDrawSupportDirection;
-		attribute boolean mDrawGetSupportingFace;
-		attribute boolean mDrawShape;
-		attribute boolean mDrawShapeWireframe;
-		attribute EShapeColor mDrawShapeColor;
-		attribute boolean mDrawBoundingBox;
-		attribute boolean mDrawCenterOfMassTransform;
-		attribute boolean mDrawWorldTransform;
-		attribute boolean mDrawVelocity;
-		attribute boolean mDrawMassAndInertia;
-		attribute boolean mDrawSleepStats;
-		attribute boolean mDrawSoftBodyVertices;
-		attribute boolean mDrawSoftBodyVertexVelocities;
-		attribute boolean mDrawSoftBodyEdgeConstraints;
-		attribute boolean mDrawSoftBodyBendConstraints;
-		attribute boolean mDrawSoftBodyVolumeConstraints;
-		attribute boolean mDrawSoftBodySkinConstraints;
-		attribute boolean mDrawSoftBodyLRAConstraints;
-		attribute boolean mDrawSoftBodyPredictedBounds;
+	void BodyManagerDrawSettings();
+
+	attribute boolean mDrawGetSupportFunction;
+	attribute boolean mDrawSupportDirection;
+	attribute boolean mDrawGetSupportingFace;
+	attribute boolean mDrawShape;
+	attribute boolean mDrawShapeWireframe;
+	attribute EShapeColor mDrawShapeColor;
+	attribute boolean mDrawBoundingBox;
+	attribute boolean mDrawCenterOfMassTransform;
+	attribute boolean mDrawWorldTransform;
+	attribute boolean mDrawVelocity;
+	attribute boolean mDrawMassAndInertia;
+	attribute boolean mDrawSleepStats;
+	attribute boolean mDrawSoftBodyVertices;
+	attribute boolean mDrawSoftBodyVertexVelocities;
+	attribute boolean mDrawSoftBodyEdgeConstraints;
+	attribute boolean mDrawSoftBodyBendConstraints;
+	attribute boolean mDrawSoftBodyVolumeConstraints;
+	attribute boolean mDrawSoftBodySkinConstraints;
+	attribute boolean mDrawSoftBodyLRAConstraints;
+	attribute boolean mDrawSoftBodyPredictedBounds;
+	attribute ESoftBodyConstraintColor mDrawSoftBodyConstraintColor;
 };
 
 interface DebugRendererVertexTraits
@@ -66,27 +73,25 @@ interface DebugRendererTriangleTraits
 	static readonly attribute unsigned long mSize;
 };
 
-
-interface DebugRendererEm { 
+interface DebugRendererEm {
 	void Initialize();
-  void DrawBodies(PhysicsSystem system, BodyManagerDrawSettings inDrawSettings);
-  void DrawBodies(PhysicsSystem system);
-  void DrawConstraints(PhysicsSystem system);
-  void DrawConstraintLimits(PhysicsSystem system);
-  void DrawConstraintReferenceFrame(PhysicsSystem system);
-  void DrawShape(Shape inShape, [Const] RMat44 inModelMatrix, [Const] RVec3 inScale, [Const] Color inColor, boolean inDrawWireFrame);
-  void DrawBody(Body body, [Const] Color inColor, boolean inDrawWireFrame);
-  void DrawConstraint(Constraint inConstraint);
+	void DrawBodies(PhysicsSystem system, BodyManagerDrawSettings inDrawSettings);
+	void DrawBodies(PhysicsSystem system);
+	void DrawConstraints(PhysicsSystem system);
+	void DrawConstraintLimits(PhysicsSystem system);
+	void DrawConstraintReferenceFrame(PhysicsSystem system);
+	void DrawShape(Shape inShape, [Const] RMat44 inModelMatrix, [Const] RVec3 inScale, [Const] Color inColor, boolean inDrawWireFrame);
+	void DrawBody(Body body, [Const] Color inColor, boolean inDrawWireFrame);
+	void DrawConstraint(Constraint inConstraint);
 };
 
-[JSImplementation="DebugRendererEm"]
-interface DebugRendererJS: DebugRendererEm {
-  void DebugRendererJS();
-  void DrawLine([Const] RVec3 inFrom, [Const] RVec3 inTo, [Const] Color inColor);
-  void DrawTriangle([Const] RVec3 inV1, [Const] RVec3 inV2,[Const]  RVec3 inV3, [Const] Color inColor, ECastShadow inCastShadow);
-  void DrawText3D([Const] RVec3 inPosition, [Const] any inString, unsigned long inStringLen, [Const] Color inColor, float inHeight);
-  
-  void DrawGeometryWithID([Const] RMat44 inModelMatrix, [Const] AABox inWorldSpaceBounds, float inLODScaleSq, Color inModelColor, [Const] unsigned long inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode);
-  unsigned long CreateTriangleBatchID([Const] any inTriangles, long inTriangleCount);
-  unsigned long CreateTriangleBatchIDWithIndex([Const] any inVertices, long inVertexCount, [Const] any inIndices, long inIndexCount);
+[JSImplementation = "DebugRendererEm"]
+interface DebugRendererJS : DebugRendererEm {
+	void DebugRendererJS();
+	void DrawLine([Const] RVec3 inFrom, [Const] RVec3 inTo, [Const] Color inColor);
+	void DrawTriangle([Const] RVec3 inV1, [Const] RVec3 inV2, [Const]  RVec3 inV3, [Const] Color inColor, ECastShadow inCastShadow);
+	void DrawText3D([Const] RVec3 inPosition, [Const] any inString, unsigned long inStringLen, [Const] Color inColor, float inHeight);
+	void DrawGeometryWithID([Const] RMat44 inModelMatrix, [Const] AABox inWorldSpaceBounds, float inLODScaleSq, Color inModelColor, [Const] unsigned long inGeometryID, ECullMode inCullMode, ECastShadow inCastShadow, EDrawMode inDrawMode);
+	unsigned long CreateTriangleBatchID([Const] any inTriangles, long inTriangleCount);
+	unsigned long CreateTriangleBatchIDWithIndex([Const] any inVertices, long inVertexCount, [Const] any inIndices, long inIndexCount);
 };

--- a/JoltJS.h
+++ b/JoltJS.h
@@ -75,6 +75,10 @@
 using namespace JPH;
 using namespace std;
 
+#ifdef JPH_DEBUG_RENDERER
+	#include "JoltJS-DebugRenderer.h"
+#endif
+
 // Ensure that we use 32-bit object layers
 static_assert(sizeof(ObjectLayer) == 4);
 

--- a/build.sh
+++ b/build.sh
@@ -28,11 +28,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-npx webidl-dts-gen -e -d -i ./JoltJS.idl -o ./dist/types.d.ts -n Jolt
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-
 cat > ./dist/jolt-physics.d.ts << EOF
 import Jolt from "./types";
 


### PR DESCRIPTION
Debug Renderer
* Move typescript typing generation into CMake - supports CMake modifiable IDL file
* Conditional inclusion of debug-renderer IDL into build and typings
* THREE.JS - CSS3D Renderer (used for text display in Debug Renderer)
* 
* Example Three.JS DebugRendererJS implementation
* Demo using Debug Renderer, using widget to show flag usages

The example Renderer demo is currently set to check for the Jolt.DebugRendererJS class, so the page will do nothing on non-distribution builds and the github-pages site, so I did not include it on the index.html