### PR TITLE
Expose methods on `OrientedBox`

### DIFF
--- a/JoltJS.idl
+++ b/JoltJS.idl
@@ -670,6 +670,10 @@ interface AABox {
 interface OrientedBox {
 	void OrientedBox();
 	void OrientedBox([Const, Ref] Mat44 inOrientation, [Const, Ref] Vec3 inHalfExtents);
+	void OrientedBox([Const, Ref] Mat44 inOrientation, [Const, Ref] AABox inBox);
+
+    boolean Overlaps([Const, Ref] AABox inBox, optional float inEpsilon=1.0=-6f);
+    boolean Overlaps([Const, Ref] OrientedBox inBox, optional float inEpsilon=1.0=-6f);
 
 	[Value] attribute Mat44 mOrientation;
 	[Value] attribute Vec3 mHalfExtents;


### PR DESCRIPTION
Currently, not all methods are exposed for the `OrientedBox` interface. [Autodesk Synthesis](https://github.com/Autodesk/synthesis) needs oriented boxes to define zones on game-fields.

This PR exposes all public methods on the `OrientedBox` class.

Any feedback on this PR would be greatly appreciated.